### PR TITLE
21.co -> earn.com, don't parse fee json on non 2XX status

### DIFF
--- a/bit/network/fees.py
+++ b/bit/network/fees.py
@@ -64,7 +64,11 @@ def get_fee_local_cache(f):
 
             if not cached_fee_hour or now - hour_last_update > DEFAULT_CACHE_TIME:
                 try:
-                    cached_fee_hour = requests.get(URL).json()['hourFee']
+                    request = requests.get(URL)
+                    # If we have a non 2XX status code, raise HTTPError.
+                    request.raise_for_status()
+                    # Otherwise, try to parse json as normal.
+                    cached_fee_hour = request.json()['hourFee']
                     hour_last_update = now
                 except (ConnectionError, Timeout):  # pragma: no cover
                     return cached_fee_hour or DEFAULT_FEE_HOUR

--- a/bit/network/fees.py
+++ b/bit/network/fees.py
@@ -70,7 +70,7 @@ def get_fee_local_cache(f):
                     # Otherwise, try to parse json as normal.
                     cached_fee_hour = request.json()['hourFee']
                     hour_last_update = now
-                except (ConnectionError, Timeout):  # pragma: no cover
+                except (ConnectionError, HTTPError, Timeout):  # pragma: no cover
                     return cached_fee_hour or DEFAULT_FEE_HOUR
 
             return cached_fee_hour

--- a/bit/network/fees.py
+++ b/bit/network/fees.py
@@ -2,7 +2,7 @@ from functools import wraps
 from time import time
 
 import requests
-from requests.exceptions import ConnectionError, Timeout, HTTPError
+from requests.exceptions import ConnectionError, HTTPError, Timeout
 
 DEFAULT_FEE_FAST = 220
 DEFAULT_FEE_HOUR = 160
@@ -53,7 +53,7 @@ def get_fee_local_cache(f):
                     # Otherwise, try to parse json as normal.
                     cached_fee_fast = request.json()['fastestFee']
                     fast_last_update = now
-                except (ConnectionError, Timeout, HTTPError):  # pragma: no cover
+                except (ConnectionError, HTTPError, Timeout):  # pragma: no cover
                     return cached_fee_fast or DEFAULT_FEE_FAST
 
             return cached_fee_fast

--- a/bit/wallet.py
+++ b/bit/wallet.py
@@ -204,7 +204,7 @@ class PrivateKey(BaseKey):
                         must be :ref:`supported <supported currencies>`.
         :type outputs: ``list`` of ``tuple``
         :param fee: The number of satoshi per byte to pay to miners. By default
-                    Bit will poll `<https://bitcoinfees.21.co>`_ and use a fee
+                    Bit will poll `<https://bitcoinfees.earn.com>`_ and use a fee
                     that will allow your transaction to be confirmed as soon as
                     possible.
         :type fee: ``int``
@@ -252,7 +252,7 @@ class PrivateKey(BaseKey):
                         must be :ref:`supported <supported currencies>`.
         :type outputs: ``list`` of ``tuple``
         :param fee: The number of satoshi per byte to pay to miners. By default
-                    Bit will poll `<https://bitcoinfees.21.co>`_ and use a fee
+                    Bit will poll `<https://bitcoinfees.earn.com>`_ and use a fee
                     that will allow your transaction to be confirmed as soon as
                     possible.
         :type fee: ``int``
@@ -300,7 +300,7 @@ class PrivateKey(BaseKey):
                            compressed public key. This influences the fee.
         :type compressed: ``bool``
         :param fee: The number of satoshi per byte to pay to miners. By default
-                    Bit will poll `<https://bitcoinfees.21.co>`_ and use a fee
+                    Bit will poll `<https://bitcoinfees.earn.com>`_ and use a fee
                     that will allow your transaction to be confirmed as soon as
                     possible.
         :type fee: ``int``
@@ -488,7 +488,7 @@ class PrivateKeyTestnet(BaseKey):
                         must be :ref:`supported <supported currencies>`.
         :type outputs: ``list`` of ``tuple``
         :param fee: The number of satoshi per byte to pay to miners. By default
-                    Bit will poll `<https://bitcoinfees.21.co>`_ and use a fee
+                    Bit will poll `<https://bitcoinfees.earn.com>`_ and use a fee
                     that will allow your transaction to be confirmed as soon as
                     possible.
         :type fee: ``int``
@@ -536,7 +536,7 @@ class PrivateKeyTestnet(BaseKey):
                         must be :ref:`supported <supported currencies>`.
         :type outputs: ``list`` of ``tuple``
         :param fee: The number of satoshi per byte to pay to miners. By default
-                    Bit will poll `<https://bitcoinfees.21.co>`_ and use a fee
+                    Bit will poll `<https://bitcoinfees.earn.com>`_ and use a fee
                     that will allow your transaction to be confirmed as soon as
                     possible.
         :type fee: ``int``
@@ -584,7 +584,7 @@ class PrivateKeyTestnet(BaseKey):
                            compressed public key. This influences the fee.
         :type compressed: ``bool``
         :param fee: The number of satoshi per byte to pay to miners. By default
-                    Bit will poll `<https://bitcoinfees.21.co>`_ and use a fee
+                    Bit will poll `<https://bitcoinfees.earn.com>`_ and use a fee
                     that will allow your transaction to be confirmed as soon as
                     possible.
         :type fee: ``int``

--- a/docs/source/guide/fees.rst
+++ b/docs/source/guide/fees.rst
@@ -7,7 +7,7 @@ Bit provides a convenient way to get recommended satoshi/byte fees in the
 form of :func:`~bit.network.get_fee` and :func:`~bit.network.get_fee_cached`,
 the latter of which will cache results for 10 minutes
 :ref:`by default <cache times>`. Currently, the only service in
-use is `<https://bitcoinfees.21.co>`_.
+use is `<https://bitcoinfees.earn.com>`_.
 
 Each function takes an optional argument ``fast`` that is ``True`` by default.
 If ``True``, the fee returned will be "The lowest fee (in satoshis per byte)

--- a/docs/source/guide/transactions.rst
+++ b/docs/source/guide/transactions.rst
@@ -64,7 +64,7 @@ Fee
 
     -- Coinbase
 
-By default, Bit will poll `<https://bitcoinfees.21.co>`_ and use a fee that
+By default, Bit will poll `<https://bitcoinfees.earn.com>`_ and use a fee that
 will allow your transaction to be confirmed as soon as possible.
 
 You can change the satoshi per byte fee like so:


### PR DESCRIPTION
21.co has rebraded to earn.com. This converts all 21.co URLs to
earn.com.

Prior to this commit, if requesting say over Tor bit would try to
parse json on the 4XX reply returned by earn.com's CloudFlare
service. Now, we raise an exception on such status codes and
proceed to use the fee constant.