### PR TITLE
Allow sending to P2SH addresses

### DIFF
--- a/bit/format.py
+++ b/bit/format.py
@@ -45,9 +45,9 @@ def address_to_public_key_hash(address):
 def get_version(address):
     version = b58decode_check(address)[:1]
 
-    if version == MAIN_PUBKEY_HASH:
+    if version in (MAIN_PUBKEY_HASH, MAIN_SCRIPT_HASH):
         return 'main'
-    elif version == TEST_PUBKEY_HASH:
+    elif version in (TEST_PUBKEY_HASH, TEST_SCRIPT_HASH):
         return 'test'
     else:
         raise ValueError('{} does not correspond to a mainnet nor '


### PR DESCRIPTION
Since #12 was merged there are no more obstacles to send bitcoins to P2SH but `get_version` method throwing an exception on `\x05` first byte.

So this PR fixes the issue allowing to send to any address.

Example of sent TX: https://www.blockchain.com/btc/tx/b519044528f1dc811ee58d7caee657766cb41449749fd1e82347bff2edbdcb90

