### PR TITLE
grow to v0.5.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,14 @@ Release History
 Unreleased (see `master <https://github.com/ofek/bit>`_)
 --------------------------------------------------------
 
+0.5.0 (2019-02-19)
+------------------
+
+- New :class:`~bit.MultiSig` adds support for P2SH nested m-of-n multisignature contracts
+- Support for sending to P2SH and Bech32 output addresses
+- P2SH nested segwit addresses for :class:`~bit.PrivateKey` and :class:`~bit.MultiSig`
+- Support for batching transaction inputs from different keys
+
 0.4.3 (2018-03-11)
 ------------------
 

--- a/bit/__init__.py
+++ b/bit/__init__.py
@@ -4,4 +4,4 @@ from bit.network.rates import SUPPORTED_CURRENCIES, set_rate_cache_time
 from bit.network.services import set_service_timeout
 from bit.wallet import Key, PrivateKey, PrivateKeyTestnet, wif_to_key, MultiSig, MultiSigTestnet
 
-__version__ = '0.4.3'
+__version__ = '0.5.0'

--- a/docs/source/guide/keys.rst
+++ b/docs/source/guide/keys.rst
@@ -70,15 +70,15 @@ both `key1` and `key2` to spend from:
     >>> key2 = Key()
     >>> multisig = MultiSig(key1, {key1.public_key, key2.public_key}, 2)
 
-IMPORTANT:
+**IMPORTANT:**
 
 When providing as argument public keys with a set such as above, then Bit will
 sort the public keys internally in lexicographical order similar to how
 `Electrum`_ behaves.
 If the public keys are provided with a list, then the ordering of the public
 keys of that list are used, similar to how Bitcoin Core behaves.
-Calling `~bit.MultiSig.public_keys` will always output a list with the public
-keys in the order they are being used by in Bit.
+Calling :param:`~bit.MultiSig.public_keys` will always return a list with the
+public keys in the order they are being used by in the multisignature contract.
 
 Public Point
 ------------
@@ -261,6 +261,6 @@ Export:
 .. _elliptic curve: https://en.wikipedia.org/wiki/Elliptic_curve
 .. _SEC: https://en.wikipedia.org/wiki/SECG
 .. _secp256k1: https://en.bitcoin.it/wiki/Secp256k1
-:: _multisignature: https://en.bitcoin.it/wiki/Multisignature
+.. _multisignature: https://en.bitcoin.it/wiki/Multisignature
 .. _Electrum: https://electrum.org
 .. _wallet import format: https://en.bitcoin.it/wiki/Private_key#Base58_Wallet_Import_format

--- a/docs/source/guide/transactions.rst
+++ b/docs/source/guide/transactions.rst
@@ -71,12 +71,12 @@ Batching
 Batching transactions allows adding multiple unspents from diferent keys to a
 single transaction. This can be done with Bit in the following way:
 
-It is possible to manually provide `~bit.network.meta.Unspent` objects when
+It is possible to manually provide :class:`~bit.network.meta.Unspent` objects when
 calling :func:`create_transaction` on any key object. If provided with unspents
 that do not belong to the key that calls :func:`create_transaction`, then those
 unspents will still be added to the transaction without being signed.
 
-Likewise, the transaction with some unsigned inputs left can be passed to
+Likewise, a transaction with some unsigned inputs left can be passed to
 :func:`sign_transaction` of an instance of a key object that can sign an
 input and the signature will be added, similar to how multisignature inputs are
 signed.


### PR DESCRIPTION
New release that officially supports the numerous features outlined in `HISTORY.rst`.

Tiny errors in the references inside docs have been fixed. Otherwise the docs are already up-to-date and TravisCI has already build them, see e.g. [here](https://ofek.github.io/bit/guide/keys.html#types).