### PR TITLE
Change MESSAGE_LIMIT to 80

### DIFF
--- a/bit/constants.py
+++ b/bit/constants.py
@@ -19,7 +19,7 @@ OP_PUSH_32 = b'\x20'
 OP_RETURN = b'\x6a'
 OP_EQUAL = b'\x87'
 
-MESSAGE_LIMIT = 40
+MESSAGE_LIMIT = 80
 
 # Address formats:
 BECH32_VERSION_SET = ('bc', 'tb', 'bcrt')

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -605,7 +605,7 @@ class TestConstructOutputBlock:
         amount = b'\x00\x00\x00\x00\x00\x00\x00\x00'
         _, outputs = sanitize_tx_data(
             UNSPENTS, [(out[0], out[1], 'satoshi') for out in OUTPUTS], 0, RETURN_ADDRESS,
-            message='hello'*9, version='test'
+            message='hello'*18, version='test'
         )
         outs = construct_outputs(outputs)
         assert len(outs) == 5 and outs[3].amount == amount and outs[4].amount == amount

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -605,7 +605,7 @@ class TestConstructOutputBlock:
         amount = b'\x00\x00\x00\x00\x00\x00\x00\x00'
         _, outputs = sanitize_tx_data(
             UNSPENTS, [(out[0], out[1], 'satoshi') for out in OUTPUTS], 0, RETURN_ADDRESS,
-            message='hello'*17, version='test'
+            message='hello'*18, version='test'
         )
         outs = construct_outputs(outputs)
         assert len(outs) == 5 and outs[3].amount == amount and outs[4].amount == amount

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -605,7 +605,7 @@ class TestConstructOutputBlock:
         amount = b'\x00\x00\x00\x00\x00\x00\x00\x00'
         _, outputs = sanitize_tx_data(
             UNSPENTS, [(out[0], out[1], 'satoshi') for out in OUTPUTS], 0, RETURN_ADDRESS,
-            message='hello'*18, version='test'
+            message='hello'*9, version='test'
         )
         outs = construct_outputs(outputs)
         assert len(outs) == 5 and outs[3].amount == amount and outs[4].amount == amount

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -605,7 +605,7 @@ class TestConstructOutputBlock:
         amount = b'\x00\x00\x00\x00\x00\x00\x00\x00'
         _, outputs = sanitize_tx_data(
             UNSPENTS, [(out[0], out[1], 'satoshi') for out in OUTPUTS], 0, RETURN_ADDRESS,
-            message='hello'*9, version='test'
+            message='hello'*17, version='test'
         )
         outs = construct_outputs(outputs)
         assert len(outs) == 5 and outs[3].amount == amount and outs[4].amount == amount


### PR DESCRIPTION
Ever since Bitcoin Core 0.11.x the OP_RETURN function allows 80 bytes of data to be written to a transaction.

https://bitcoin.org/en/developer-guide#term-null-data