### PR TITLE
Add `get_transaction_by_id` calls

### DIFF
--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -320,7 +320,7 @@ class NetworkAPI:
     GET_TRANSACTIONS_MAIN = [BitpayAPI.get_transactions,  # Limit 1000
                              SmartbitAPI.get_transactions,  # Limit 1000
                              BlockchainAPI.get_transactions]  # No limit, requires multiple requests
-    GET_TRANSACTIONS_BY_ID_MAIN = [BitpayAPI.get_transaction_by_id, # Limit 1000
+    GET_TRANSACTION_BY_ID_MAIN = [BitpayAPI.get_transaction_by_id, # Limit 1000
                                     SmartbitAPI.get_transaction_by_id, # Limit 1000
                                     BlockchainAPI.get_transaction_by_id]  # No limit, requires multiple requests
     GET_UNSPENT_MAIN = [BitpayAPI.get_unspent,  # No limit
@@ -334,7 +334,7 @@ class NetworkAPI:
                         SmartbitAPI.get_balance_testnet]
     GET_TRANSACTIONS_TEST = [BitpayAPI.get_transactions_testnet,  # Limit 1000
                              SmartbitAPI.get_transactions_testnet]  # Limit 1000
-    GET_TRANSACTIONS_BY_ID_TEST = [BitpayAPI.get_transaction_by_id_testnet, # Limit 1000
+    GET_TRANSACTION_BY_ID_TEST = [BitpayAPI.get_transaction_by_id_testnet, # Limit 1000
                                     SmartbitAPI.get_transaction_by_id_testnet] # Limit 1000
     GET_UNSPENT_TEST = [BitpayAPI.get_unspent_testnet,  # No limit
                         SmartbitAPI.get_unspent_testnet]  # Limit 1000
@@ -424,7 +424,7 @@ class NetworkAPI:
         :rtype: ``TxObj``
         """
 
-        for api_call in cls.GET_TRANSACTIONS_BY_ID_MAIN:
+        for api_call in cls.GET_TRANSACTION_BY_ID_MAIN:
             try:
                 return deserialize(api_call(txid))
             except cls.IGNORED_ERRORS:
@@ -442,9 +442,9 @@ class NetworkAPI:
         :rtype: ``TxObj``
         """
 
-        for api_call in cls.GET_TRANSACTIONS_BY_ID_TEST:
+        for api_call in cls.GET_TRANSACTION_BY_ID_TEST:
             try:
-                return api_call(txid)
+                return deserialize(api_call(txid))
             except cls.IGNORED_ERRORS:
                 pass
 

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -43,7 +43,7 @@ class InsightAPI:
             return None
         if r.status_code != 200: #pragma: no cover
             raise ConnectionError
-        return deserialize(r.json()["rawtx"])
+        return r.json()["rawtx"]
 
     @classmethod
     def get_unspent(cls, address):
@@ -101,7 +101,7 @@ class BitpayAPI(InsightAPI):
             return None
         if r.status_code != 200: #pragma: no cover
             raise ConnectionError
-        return deserialize(r.json()["rawtx"])
+        return r.json()["rawtx"]
 
     @classmethod
     def get_unspent_testnet(cls, address):
@@ -168,7 +168,7 @@ class BlockchainAPI:
             return None
         if r.status_code != 200:  # pragma: no cover
             raise ConnectionError
-        return deserialize(r.text)
+        return r.text
 
     @classmethod
     def get_unspent(cls, address):
@@ -199,12 +199,12 @@ class SmartbitAPI:
     MAIN_ADDRESS_API = MAIN_ENDPOINT + 'address/'
     MAIN_UNSPENT_API = MAIN_ADDRESS_API + '{}/unspent'
     MAIN_TX_PUSH_API = MAIN_ENDPOINT + 'pushtx'
-    MAIN_TX_API = MAIN_ENDPOINT + 'tx/'
+    MAIN_TX_API = MAIN_ENDPOINT + 'tx/{}/hex'
     TEST_ENDPOINT = 'https://testnet-api.smartbit.com.au/v1/blockchain/'
     TEST_ADDRESS_API = TEST_ENDPOINT + 'address/'
     TEST_UNSPENT_API = TEST_ADDRESS_API + '{}/unspent'
     TEST_TX_PUSH_API = TEST_ENDPOINT + 'pushtx'
-    TEST_TX_API = TEST_ENDPOINT + 'tx/'
+    TEST_TX_API = TEST_ENDPOINT + 'tx/{}/hex'
     TX_PUSH_PARAM = 'hex'
 
     @classmethod
@@ -238,12 +238,12 @@ class SmartbitAPI:
 
     @classmethod
     def get_transaction_by_id(cls, txid):
-        r = requests.get(cls.MAIN_TX_API + txid+ '/hex?limit=1000', timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.MAIN_TX_API.format(txid) + '?limit=1000', timeout=DEFAULT_TIMEOUT)
         if r.status_code == 400:
             return None
         if r.status_code != 200:  # pragma: no cover
             raise ConnectionError
-        return deserialize(r.json()['hex'][0]['hex'])
+        return r.json()['hex'][0]['hex']
 
     @classmethod
     def get_transactions_testnet(cls, address):
@@ -262,12 +262,12 @@ class SmartbitAPI:
 
     @classmethod
     def get_transaction_by_id_testnet(cls, txid):
-        r = requests.get(cls.TEST_TX_API + txid+ '/hex?limit=1000', timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.TEST_TX_API.format(txid) + '?limit=1000', timeout=DEFAULT_TIMEOUT)
         if r.status_code == 400:
             return None
         if r.status_code != 200:  # pragma: no cover
             raise ConnectionError
-        return deserialize(r.json()['hex'][0]['hex'])
+        return r.json()['hex'][0]['hex']
 
     @classmethod
     def get_unspent(cls, address):

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -416,7 +416,7 @@ class NetworkAPI:
 
     @classmethod
     def get_transaction_by_id(cls, txid):
-        """Gets a transaction by it's txid.
+        """Gets a transaction by its transaction id (txid).
 
         :param txid: The id of the transaction
         :type txid: ``str``
@@ -434,7 +434,7 @@ class NetworkAPI:
 
     @classmethod
     def get_transaction_by_id_testnet(cls, txid):
-        """Gets a transaction by it's txid on the test.
+        """Gets a transaction by its transaction id (txid) on the test.
 
         :param txid: The id of the transaction
         :type txid: ``str``

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -416,17 +416,17 @@ class NetworkAPI:
 
     @classmethod
     def get_transaction_by_id(cls, txid):
-        """Gets a transaction by its transaction id (txid).
+        """Gets a rax transaction hex by its transaction id (txid).
 
         :param txid: The id of the transaction
         :type txid: ``str``
         :raises ConnectionError: If all API services fail.
-        :rtype: ``TxObj``
+        :rtype: ``string``
         """
 
         for api_call in cls.GET_TRANSACTION_BY_ID_MAIN:
             try:
-                return deserialize(api_call(txid))
+                return api_call(txid)
             except cls.IGNORED_ERRORS:
                 pass
 
@@ -434,17 +434,17 @@ class NetworkAPI:
 
     @classmethod
     def get_transaction_by_id_testnet(cls, txid):
-        """Gets a transaction by its transaction id (txid) on the test.
+        """Gets a raw transaction hex by its transaction id (txid) on the test.
 
         :param txid: The id of the transaction
         :type txid: ``str``
         :raises ConnectionError: If all API services fail.
-        :rtype: ``TxObj``
+        :rtype: ``string``
         """
 
         for api_call in cls.GET_TRANSACTION_BY_ID_TEST:
             try:
-                return deserialize(api_call(txid))
+                return api_call(txid)
             except cls.IGNORED_ERRORS:
                 pass
 

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -416,7 +416,7 @@ class NetworkAPI:
 
     @classmethod
     def get_transaction_by_id(cls, txid):
-        """Gets a rax transaction hex by its transaction id (txid).
+        """Gets a raw transaction hex by its transaction id (txid).
 
         :param txid: The id of the transaction
         :type txid: ``str``

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -3,8 +3,6 @@ import requests
 from bit.network import currency_to_satoshi
 from bit.network.meta import Unspent
 
-from bit.transaction import deserialize
-
 DEFAULT_TIMEOUT = 10
 
 

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -320,9 +320,9 @@ class NetworkAPI:
     GET_TRANSACTIONS_MAIN = [BitpayAPI.get_transactions,  # Limit 1000
                              SmartbitAPI.get_transactions,  # Limit 1000
                              BlockchainAPI.get_transactions]  # No limit, requires multiple requests
-    GET_TRANSACTION_BY_ID_MAIN = [BitpayAPI.get_transaction_by_id, # Limit 1000
-                                    SmartbitAPI.get_transaction_by_id, # Limit 1000
-                                    BlockchainAPI.get_transaction_by_id]  # No limit, requires multiple requests
+    GET_TRANSACTION_BY_ID_MAIN = [BitpayAPI.get_transaction_by_id,
+                                  SmartbitAPI.get_transaction_by_id,
+                                  BlockchainAPI.get_transaction_by_id]
     GET_UNSPENT_MAIN = [BitpayAPI.get_unspent,  # No limit
                         SmartbitAPI.get_unspent,  # Limit 1000
                         BlockchainAPI.get_unspent]  # Limit 250
@@ -334,8 +334,8 @@ class NetworkAPI:
                         SmartbitAPI.get_balance_testnet]
     GET_TRANSACTIONS_TEST = [BitpayAPI.get_transactions_testnet,  # Limit 1000
                              SmartbitAPI.get_transactions_testnet]  # Limit 1000
-    GET_TRANSACTION_BY_ID_TEST = [BitpayAPI.get_transaction_by_id_testnet, # Limit 1000
-                                    SmartbitAPI.get_transaction_by_id_testnet] # Limit 1000
+    GET_TRANSACTION_BY_ID_TEST = [BitpayAPI.get_transaction_by_id_testnet,
+                                  SmartbitAPI.get_transaction_by_id_testnet]
     GET_UNSPENT_TEST = [BitpayAPI.get_unspent_testnet,  # No limit
                         SmartbitAPI.get_unspent_testnet]  # Limit 1000
     BROADCAST_TX_TEST = [BitpayAPI.broadcast_tx_testnet,

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -8,6 +8,8 @@ from tests.utils import (
     catch_errors_raise_warnings, decorate_methods, raise_connection_error
 )
 
+from bit.transaction import calc_txid
+
 MAIN_ADDRESS_USED1 = '1L2JsXHPMYuAa9ugvHGLwkdstCPUDemNCf'
 MAIN_ADDRESS_USED2 = '17SkEw2md5avVNyYgj6RiXuQKNwkXaxFyQ'
 MAIN_ADDRESS_UNUSED = '1DvnoW4vsXA1H9KDgNiMqY7iNkzC187ve1'
@@ -16,9 +18,9 @@ TEST_ADDRESS_USED2 = 'mmvP3mTe53qxHdPqXEvdu8WdC7GfQ2vmx5'
 TEST_ADDRESS_USED3 = 'mpnrLMH4m4e6dS8Go84P1r2hWwTiFTXmtW'
 TEST_ADDRESS_UNUSED = 'mp1xDKvvZ4yd8h9mLC4P76syUirmxpXhuk'
 
-MAIN_TX_VALID = '' #TODO
+MAIN_TX_VALID = '6e05c708d88cc5bf0f1533938c969de2cc48f438b0ae28ce89fefbaa1938185a'
 TEST_TX_VALID = 'ff2b4641481f1ee553ba2c9f02f413a86f70240c35b5aee554f84e3efee93292'
-TX_INVALID = 'xxx'
+TX_INVALID = 'ff2b4641481f1ee553ba2c9f02f413a86f70240c35b5aee554f84e3efee93290'
 
 def all_items_common(seq):
     initial_set = set(seq[0])
@@ -135,14 +137,13 @@ class TestBitpayAPI:
         assert len(BitpayAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
 
     def test_get_transaction_by_id_valid(self):
-        assert True #TODO
-        #assert BitpayAPI.get_transaction_by_id(TEST_TX_VALID)['txid'] == TEST_TX_VALID
+        assert calc_txid(BitpayAPI.get_transaction_by_id(MAIN_TX_VALID).to_hex()) == MAIN_TX_VALID
 
     def test_get_transaction_by_id_invalid(self):
-        assert BitpayAPI.get_transaction_by_id(TEST_TX_VALID) == None
+        assert BitpayAPI.get_transaction_by_id(TX_INVALID) == None
 
     def test_get_transaction_by_id_test_valid(self):
-        assert BitpayAPI.get_transaction_by_id_testnet(TEST_TX_VALID)['txid'] == TEST_TX_VALID
+        assert calc_txid(BitpayAPI.get_transaction_by_id_testnet(TEST_TX_VALID).to_hex()) == TEST_TX_VALID
 
     def test_get_transaction_by_id_test_invalid(self):
         assert BitpayAPI.get_transaction_by_id_testnet(TX_INVALID) == None
@@ -184,11 +185,10 @@ class TestBlockchainAPI:
         assert len(BlockchainAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
 
     def test_get_transaction_by_id_valid(self):
-        assert True #TODO
-        #assert BlockchainAPI.get_transaction_by_id(TEST_TX_VALID)['hash'] == TEST_TX_VALID
+        assert calc_txid(BlockchainAPI.get_transaction_by_id(MAIN_TX_VALID).to_hex()) == MAIN_TX_VALID
 
     def test_get_transaction_by_id_invalid(self):
-        assert BlockchainAPI.get_transaction_by_id(TEST_TX_VALID) == None
+        assert BlockchainAPI.get_transaction_by_id(TX_INVALID) == None
 
     def test_get_unspent_return_type(self):
         assert iter(BlockchainAPI.get_unspent(MAIN_ADDRESS_USED1))
@@ -233,14 +233,13 @@ class TestSmartbitAPI:
         assert len(SmartbitAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
 
     def test_get_transaction_by_id_valid(self):
-        assert True #TODO
-        #assert SmartbitAPI.get_transaction_by_id(TEST_TX_VALID)['txid'] == TEST_TX_VALID
+        assert calc_txid(SmartbitAPI.get_transaction_by_id(MAIN_TX_VALID).to_hex()) == MAIN_TX_VALID
 
     def test_get_transaction_by_id_invalid(self):
-        assert SmartbitAPI.get_transaction_by_id(TEST_TX_VALID) == None
+        assert SmartbitAPI.get_transaction_by_id(TX_INVALID) == None
 
     def test_get_transaction_by_id_test_valid(self):
-        assert SmartbitAPI.get_transaction_by_id_testnet(TEST_TX_VALID)['txid'] == TEST_TX_VALID
+        assert calc_txid(SmartbitAPI.get_transaction_by_id_testnet(TEST_TX_VALID).to_hex()) == TEST_TX_VALID
 
     def test_get_transaction_by_id_test_invalid(self):
         assert SmartbitAPI.get_transaction_by_id_testnet(TX_INVALID) == None

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -137,13 +137,13 @@ class TestBitpayAPI:
         assert len(BitpayAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
 
     def test_get_transaction_by_id_valid(self):
-        assert calc_txid(BitpayAPI.get_transaction_by_id(MAIN_TX_VALID).to_hex()) == MAIN_TX_VALID
+        assert calc_txid(BitpayAPI.get_transaction_by_id(MAIN_TX_VALID)) == MAIN_TX_VALID
 
     def test_get_transaction_by_id_invalid(self):
         assert BitpayAPI.get_transaction_by_id(TX_INVALID) == None
 
     def test_get_transaction_by_id_test_valid(self):
-        assert calc_txid(BitpayAPI.get_transaction_by_id_testnet(TEST_TX_VALID).to_hex()) == TEST_TX_VALID
+        assert calc_txid(BitpayAPI.get_transaction_by_id_testnet(TEST_TX_VALID)) == TEST_TX_VALID
 
     def test_get_transaction_by_id_test_invalid(self):
         assert BitpayAPI.get_transaction_by_id_testnet(TX_INVALID) == None
@@ -185,7 +185,7 @@ class TestBlockchainAPI:
         assert len(BlockchainAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
 
     def test_get_transaction_by_id_valid(self):
-        assert calc_txid(BlockchainAPI.get_transaction_by_id(MAIN_TX_VALID).to_hex()) == MAIN_TX_VALID
+        assert calc_txid(BlockchainAPI.get_transaction_by_id(MAIN_TX_VALID)) == MAIN_TX_VALID
 
     def test_get_transaction_by_id_invalid(self):
         assert BlockchainAPI.get_transaction_by_id(TX_INVALID) == None
@@ -233,13 +233,13 @@ class TestSmartbitAPI:
         assert len(SmartbitAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
 
     def test_get_transaction_by_id_valid(self):
-        assert calc_txid(SmartbitAPI.get_transaction_by_id(MAIN_TX_VALID).to_hex()) == MAIN_TX_VALID
+        assert calc_txid(SmartbitAPI.get_transaction_by_id(MAIN_TX_VALID)) == MAIN_TX_VALID
 
     def test_get_transaction_by_id_invalid(self):
         assert SmartbitAPI.get_transaction_by_id(TX_INVALID) == None
 
     def test_get_transaction_by_id_test_valid(self):
-        assert calc_txid(SmartbitAPI.get_transaction_by_id_testnet(TEST_TX_VALID).to_hex()) == TEST_TX_VALID
+        assert calc_txid(SmartbitAPI.get_transaction_by_id_testnet(TEST_TX_VALID)) == TEST_TX_VALID
 
     def test_get_transaction_by_id_test_invalid(self):
         assert SmartbitAPI.get_transaction_by_id_testnet(TX_INVALID) == None

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -16,6 +16,9 @@ TEST_ADDRESS_USED2 = 'mmvP3mTe53qxHdPqXEvdu8WdC7GfQ2vmx5'
 TEST_ADDRESS_USED3 = 'mpnrLMH4m4e6dS8Go84P1r2hWwTiFTXmtW'
 TEST_ADDRESS_UNUSED = 'mp1xDKvvZ4yd8h9mLC4P76syUirmxpXhuk'
 
+MAIN_TX_VALID = '' #TODO
+TEST_TX_VALID = 'ff2b4641481f1ee553ba2c9f02f413a86f70240c35b5aee554f84e3efee93292'
+TX_INVALID = 'xxx'
 
 def all_items_common(seq):
     initial_set = set(seq[0])
@@ -131,6 +134,19 @@ class TestBitpayAPI:
     def test_get_transactions_test_unused(self):
         assert len(BitpayAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
 
+    def test_get_transaction_by_id_valid(self):
+        assert True #TODO
+        #assert BitpayAPI.get_transaction_by_id(TEST_TX_VALID)['txid'] == TEST_TX_VALID
+
+    def test_get_transaction_by_id_invalid(self):
+        assert BitpayAPI.get_transaction_by_id(TEST_TX_VALID) == None
+
+    def test_get_transaction_by_id_test_valid(self):
+        assert BitpayAPI.get_transaction_by_id_testnet(TEST_TX_VALID)['txid'] == TEST_TX_VALID
+
+    def test_get_transaction_by_id_test_invalid(self):
+        assert BitpayAPI.get_transaction_by_id_testnet(TX_INVALID) == None
+
     def test_get_unspent_return_type(self):
         assert iter(BitpayAPI.get_unspent(MAIN_ADDRESS_USED1))
 
@@ -166,6 +182,13 @@ class TestBlockchainAPI:
 
     def test_get_transactions_unused(self):
         assert len(BlockchainAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
+
+    def test_get_transaction_by_id_valid(self):
+        assert True #TODO
+        #assert BlockchainAPI.get_transaction_by_id(TEST_TX_VALID)['hash'] == TEST_TX_VALID
+
+    def test_get_transaction_by_id_invalid(self):
+        assert BlockchainAPI.get_transaction_by_id(TEST_TX_VALID) == None
 
     def test_get_unspent_return_type(self):
         assert iter(BlockchainAPI.get_unspent(MAIN_ADDRESS_USED1))
@@ -208,6 +231,19 @@ class TestSmartbitAPI:
 
     def test_get_transactions_test_unused(self):
         assert len(SmartbitAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
+
+    def test_get_transaction_by_id_valid(self):
+        assert True #TODO
+        #assert SmartbitAPI.get_transaction_by_id(TEST_TX_VALID)['txid'] == TEST_TX_VALID
+
+    def test_get_transaction_by_id_invalid(self):
+        assert SmartbitAPI.get_transaction_by_id(TEST_TX_VALID) == None
+
+    def test_get_transaction_by_id_test_valid(self):
+        assert SmartbitAPI.get_transaction_by_id_testnet(TEST_TX_VALID)['txid'] == TEST_TX_VALID
+
+    def test_get_transaction_by_id_test_invalid(self):
+        assert SmartbitAPI.get_transaction_by_id_testnet(TX_INVALID) == None
 
     def test_get_unspent_return_type(self):
         assert iter(SmartbitAPI.get_unspent(MAIN_ADDRESS_USED1))

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -94,7 +94,7 @@ class TestNetworkAPI:
 
     def test_get_transaction_by_id_main_failure(self):
         with pytest.raises(ConnectionError):
-            MockBackend.get_transactions(MAIN_TX_VALID)
+            MockBackend.get_transaction_by_id(MAIN_TX_VALID)
 
     def test_get_transaction_by_id_test_equal(self):
         results = [calc_txid(call(TEST_TX_VALID)) for call in NetworkAPI.GET_TRANSACTION_BY_ID_TEST]
@@ -102,7 +102,7 @@ class TestNetworkAPI:
 
     def test_get_transaction_by_id_test_failure(self):
         with pytest.raises(ConnectionError):
-            MockBackend.get_transactions_testnet(TEST_TX_VALID)
+            MockBackend.get_transaction_by_id_testnet(TEST_TX_VALID)
 
     def test_get_unspent_main_equal(self):
         results = [call(MAIN_ADDRESS_USED2) for call in NetworkAPI.GET_UNSPENT_MAIN]

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -47,11 +47,11 @@ class MockBackend(NetworkAPI):
     IGNORED_ERRORS = NetworkAPI.IGNORED_ERRORS
     GET_BALANCE_MAIN = [raise_connection_error]
     GET_TRANSACTIONS_MAIN = [raise_connection_error]
-    GET_TRANSACTIONS_BY_ID_MAIN = [raise_connection_error]
+    GET_TRANSACTION_BY_ID_MAIN = [raise_connection_error]
     GET_UNSPENT_MAIN = [raise_connection_error]
     GET_BALANCE_TEST = [raise_connection_error]
     GET_TRANSACTIONS_TEST = [raise_connection_error]
-    GET_TRANSACTIONS_BY_ID_TEST = [raise_connection_error]
+    GET_TRANSACTION_BY_ID_TEST = [raise_connection_error]
     GET_UNSPENT_TEST = [raise_connection_error]
 
 
@@ -79,6 +79,14 @@ class TestNetworkAPI:
     def test_get_transactions_main_failure(self):
         with pytest.raises(ConnectionError):
             MockBackend.get_transactions(MAIN_ADDRESS_USED1)
+
+    def test_get_transactions_test_equal(self):
+        results = [call(TEST_ADDRESS_USED2)[:100] for call in NetworkAPI.GET_TRANSACTIONS_TEST]
+        assert all_items_common(results)
+
+    def test_get_transactions_test_failure(self):
+        with pytest.raises(ConnectionError):
+            MockBackend.get_transactions_testnet(TEST_ADDRESS_USED2)
 
     def test_get_transaction_by_id_main_equal(self):
         results = [calc_txid(call(MAIN_TX_VALID)) for call in NetworkAPI.GET_TRANSACTION_BY_ID_MAIN]

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -32,7 +32,6 @@ def all_items_equal(seq):
     initial_item = seq[0]
     return all(item == initial_item for item in seq if item is not None)
 
-
 def test_set_service_timeout():
     original = bit.network.services.DEFAULT_TIMEOUT
     set_service_timeout(3)
@@ -48,9 +47,11 @@ class MockBackend(NetworkAPI):
     IGNORED_ERRORS = NetworkAPI.IGNORED_ERRORS
     GET_BALANCE_MAIN = [raise_connection_error]
     GET_TRANSACTIONS_MAIN = [raise_connection_error]
+    GET_TRANSACTIONS_BY_ID_MAIN = [raise_connection_error]
     GET_UNSPENT_MAIN = [raise_connection_error]
     GET_BALANCE_TEST = [raise_connection_error]
     GET_TRANSACTIONS_TEST = [raise_connection_error]
+    GET_TRANSACTIONS_BY_ID_TEST = [raise_connection_error]
     GET_UNSPENT_TEST = [raise_connection_error]
 
 
@@ -79,13 +80,21 @@ class TestNetworkAPI:
         with pytest.raises(ConnectionError):
             MockBackend.get_transactions(MAIN_ADDRESS_USED1)
 
-    def test_get_transactions_test_equal(self):
-        results = [call(TEST_ADDRESS_USED2)[:100] for call in NetworkAPI.GET_TRANSACTIONS_TEST]
-        assert all_items_common(results)
+    def test_get_transaction_by_id_main_equal(self):
+        results = [calc_txid(call(MAIN_TX_VALID)) for call in NetworkAPI.GET_TRANSACTION_BY_ID_MAIN]
+        assert all_items_equal(results)
 
-    def test_get_transactions_test_failure(self):
+    def test_get_transaction_by_id_main_failure(self):
         with pytest.raises(ConnectionError):
-            MockBackend.get_transactions_testnet(TEST_ADDRESS_USED2)
+            MockBackend.get_transactions(MAIN_TX_VALID)
+
+    def test_get_transaction_by_id_test_equal(self):
+        results = [calc_txid(call(TEST_TX_VALID)) for call in NetworkAPI.GET_TRANSACTION_BY_ID_TEST]
+        assert all_items_equal(results)
+
+    def test_get_transaction_by_id_test_failure(self):
+        with pytest.raises(ConnectionError):
+            MockBackend.get_transactions_testnet(TEST_TX_VALID)
 
     def test_get_unspent_main_equal(self):
         results = [call(MAIN_ADDRESS_USED2) for call in NetworkAPI.GET_UNSPENT_MAIN]
@@ -137,13 +146,15 @@ class TestBitpayAPI:
         assert len(BitpayAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
 
     def test_get_transaction_by_id_valid(self):
-        assert calc_txid(BitpayAPI.get_transaction_by_id(MAIN_TX_VALID)) == MAIN_TX_VALID
+        tx = BitpayAPI.get_transaction_by_id(MAIN_TX_VALID)
+        assert calc_txid(tx) == MAIN_TX_VALID
 
     def test_get_transaction_by_id_invalid(self):
         assert BitpayAPI.get_transaction_by_id(TX_INVALID) == None
 
     def test_get_transaction_by_id_test_valid(self):
-        assert calc_txid(BitpayAPI.get_transaction_by_id_testnet(TEST_TX_VALID)) == TEST_TX_VALID
+        tx = BitpayAPI.get_transaction_by_id_testnet(TEST_TX_VALID)
+        assert calc_txid(tx) == TEST_TX_VALID
 
     def test_get_transaction_by_id_test_invalid(self):
         assert BitpayAPI.get_transaction_by_id_testnet(TX_INVALID) == None
@@ -185,7 +196,8 @@ class TestBlockchainAPI:
         assert len(BlockchainAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
 
     def test_get_transaction_by_id_valid(self):
-        assert calc_txid(BlockchainAPI.get_transaction_by_id(MAIN_TX_VALID)) == MAIN_TX_VALID
+        tx = BlockchainAPI.get_transaction_by_id(MAIN_TX_VALID)
+        assert calc_txid(tx) == MAIN_TX_VALID
 
     def test_get_transaction_by_id_invalid(self):
         assert BlockchainAPI.get_transaction_by_id(TX_INVALID) == None
@@ -233,13 +245,15 @@ class TestSmartbitAPI:
         assert len(SmartbitAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
 
     def test_get_transaction_by_id_valid(self):
-        assert calc_txid(SmartbitAPI.get_transaction_by_id(MAIN_TX_VALID)) == MAIN_TX_VALID
+        tx = SmartbitAPI.get_transaction_by_id(MAIN_TX_VALID)
+        assert calc_txid(tx) == MAIN_TX_VALID
 
     def test_get_transaction_by_id_invalid(self):
         assert SmartbitAPI.get_transaction_by_id(TX_INVALID) == None
 
     def test_get_transaction_by_id_test_valid(self):
-        assert calc_txid(SmartbitAPI.get_transaction_by_id_testnet(TEST_TX_VALID)) == TEST_TX_VALID
+        tx = SmartbitAPI.get_transaction_by_id_testnet(TEST_TX_VALID)
+        assert calc_txid(tx) == TEST_TX_VALID
 
     def test_get_transaction_by_id_test_invalid(self):
         assert SmartbitAPI.get_transaction_by_id_testnet(TX_INVALID) == None


### PR DESCRIPTION
**What is this?**

This PR adds two new calls onto `NetworkAPI`: `get_transaction_by_id` and `get_transaction_by_id_testnet`. Both calls return a `TxObj`. Each api service has been extended to take advantage of their "raw tx" api calls. In addition, new tests have been written for each service as well as for `NetworkAPI` itself.

**Why?**

I'm already using this lib to access the blockchain, but I needed a way to grab individual transactions directly by their `txid`. This lib had everything I already needed to contact multiple apis, so rather than reinvent the wheel, I've extended this library to include the functionality I was missing.

**Why should this be merged?**

The added functions fit well with the rest of the library thematically. In addition, `get_transactions` only returns the `txid`s, but not the transactions themselves. By adding `get_transaction_by_id` we enable devs  to take that extra step to actually fetch the transaction itself. This is useful in my case because I need to fetch transactions to get `script_pubkey`.