### PR TITLE
[WIP] Adds support for `NetworkAPI` to use a remote Bitcoin node

### DIFF
--- a/bit/constants.py
+++ b/bit/constants.py
@@ -43,3 +43,10 @@ PUBLIC_KEY_UNCOMPRESSED = b'\x04'
 PUBLIC_KEY_COMPRESSED_EVEN_Y = b'\x02'
 PUBLIC_KEY_COMPRESSED_ODD_Y = b'\x03'
 PRIVATE_KEY_COMPRESSED_PUBKEY = b'\x01'
+
+# Units:
+# https://en.bitcoin.it/wiki/Units
+SATOSHI = 1
+uBTC = 10 ** 2
+mBTC = 10 ** 5
+BTC = 10 ** 8

--- a/bit/exceptions.py
+++ b/bit/exceptions.py
@@ -1,2 +1,5 @@
 class InsufficientFunds(Exception):
     pass
+
+class BitcoinNodeException(Exception):
+    pass

--- a/bit/network/rates.py
+++ b/bit/network/rates.py
@@ -5,6 +5,7 @@ from time import time
 
 import requests
 
+from bit.constants import SATOSHI, uBTC, mBTC, BTC
 from bit.utils import Decimal
 
 DEFAULT_CACHE_TIME = 60
@@ -12,12 +13,6 @@ DEFAULT_CACHE_TIME = 60
 # Constant for use in deriving exchange
 # rates when given in terms of 1 BTC.
 ONE = Decimal(1)
-
-# https://en.bitcoin.it/wiki/Units
-SATOSHI = 1
-uBTC = 10 ** 2
-mBTC = 10 ** 5
-BTC = 10 ** 8
 
 SUPPORTED_CURRENCIES = OrderedDict([
     ('satoshi', 'Satoshi'),

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -1,5 +1,6 @@
 import requests
 import json
+import logging
 from decimal import Decimal, getcontext
 
 from bit.constants import BTC
@@ -73,7 +74,8 @@ class RPCHost:
     def broadcast_tx(self, tx_hex):
         try:
             _ = self.sendrawtransaction(tx_hex)
-        except BitcoinNodeException:
+        except BitcoinNodeException as e:
+            logging.warning(e)
             return False
         return True
 

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -24,6 +24,7 @@ class RPCHost:
             port=port,
         )
         self._headers = {"content-type": "application/json"}
+        self._verify = use_https
 
     def __getattr__(self, rpc_method):
         return RPCMethod(rpc_method, self)
@@ -91,7 +92,7 @@ class RPCMethod:
         )
         try:
             response = self._host._session.post(
-                self._host._url, headers=self._host._headers, data=payload
+                self._host._url, headers=self._host._headers, data=payload, verify=self._host._verify
             )
         except requests.exceptions.ConnectionError:
             raise ConnectionError
@@ -451,8 +452,11 @@ class NetworkAPI:
         :type host: ``str``
         :param port: The port to a Bitcoin node
         :type port: ``int``
-        :param use_https: Connect to the Bitcoin node via HTTPS
-        :type use_https: ``bool``
+        :param use_https: Connect to the Bitcoin node via HTTPS. Either a
+            boolean, in which case it controls whether we connect to the node
+            via HTTP or HTTPS, or a string, in which case we connect via HTTPS
+            and it must be a path to the CA bundle to use. Defaults to False.
+        :type use_https: ``bool`` or ``string``
         :param testnet: Defines if the node should be used for testnet
         :type testnet: ``bool``
         """

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -1,5 +1,6 @@
 import requests
 import json
+from decimal import Decimal, getcontext
 
 from bit.network import currency_to_satoshi
 from bit.network.meta import Unspent
@@ -30,7 +31,9 @@ class RPCHost:
         return RPCMethod(rpc_method, self)
 
     def get_balance(self, address):
-        return self.getreceivedbyaddress(address, 0)
+        getcontext().prec = 9
+        b = Decimal(self.getreceivedbyaddress(address, 0))
+        return int(float(str(b * 100000000)))
 
     def get_balance_testnet(self, address):
         return self.get_balance(address)

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -24,7 +24,7 @@ class RPCHost:
             port=port,
         )
         self._headers = {"content-type": "application/json"}
-        self._verify = use_https
+        self._session.verify = use_https
 
     def __getattr__(self, rpc_method):
         return RPCMethod(rpc_method, self)
@@ -92,7 +92,7 @@ class RPCMethod:
         )
         try:
             response = self._host._session.post(
-                self._host._url, headers=self._host._headers, data=payload, verify=self._host._verify
+                self._host._url, headers=self._host._headers, data=payload
             )
         except requests.exceptions.ConnectionError:
             raise ConnectionError

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -2,6 +2,7 @@ import requests
 import json
 from decimal import Decimal, getcontext
 
+from bit.constants import BTC
 from bit.network import currency_to_satoshi
 from bit.network.meta import Unspent
 from bit.exceptions import BitcoinNodeException
@@ -31,9 +32,9 @@ class RPCHost:
         return RPCMethod(rpc_method, self)
 
     def get_balance(self, address):
-        getcontext().prec = 9
+        getcontext().prec = len(str(BTC))
         b = Decimal(self.getreceivedbyaddress(address, 0))
-        return int(float(str(b * 100000000)))
+        return int(b * BTC)
 
     def get_balance_testnet(self, address):
         return self.get_balance(address)

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -29,11 +29,6 @@ class RPCHost:
         self._headers = {"content-type": "application/json"}
         self._session.verify = use_https
 
-    def __eq__(self, other):
-        if isinstance(other, RPCHost):
-            return self._url == other._url and self._headers == other._headers
-        return False
-
     def __getattr__(self, rpc_method):
         return RPCMethod(rpc_method, self)
 

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -29,6 +29,11 @@ class RPCHost:
         self._headers = {"content-type": "application/json"}
         self._session.verify = use_https
 
+    def __eq__(self, other):
+        if isinstance(other, RPCHost):
+            return self._url == other._url and self._headers == other._headers
+        return False
+
     def __getattr__(self, rpc_method):
         return RPCMethod(rpc_method, self)
 

--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -465,6 +465,8 @@ class NetworkAPI:
         :type use_https: ``bool`` or ``string``
         :param testnet: Defines if the node should be used for testnet
         :type testnet: ``bool``
+        :returns: The node exposing its RPCs for direct interaction.
+        :rtype: ``RPCHost``
         """
         node = RPCHost(user=user, password=password, host=host, port=port, use_https=use_https)
 
@@ -481,6 +483,8 @@ class NetworkAPI:
             cls.GET_TRANSACTION_BY_ID_TEST = [node.get_transaction_by_id_testnet]
             cls.GET_UNSPENT_TEST = [node.get_unspent_testnet]
             cls.BROADCAST_TX_TEST = [node.broadcast_tx_testnet]
+
+        return node
 
     @classmethod
     def get_balance(cls, address):

--- a/docs/source/guide/network.rst
+++ b/docs/source/guide/network.rst
@@ -115,11 +115,21 @@ Specifically, it can access:
 - `<https://blockchain.info>`_ via :class:`~bit.network.services.BlockchainAPI`
 - `<https://smartbit.com.au>`_ via :class:`~bit.network.services.SmartbitAPI`
 
+Bit can alternatively use a remote Bitcoin node to interact with the blockchain,
+see guide below.
+
 NetworkAPI
 ^^^^^^^^^^
 
 Private key network operations use :class:`~bit.network.NetworkAPI`. For each method,
 it polls a service and if an error occurs it tries another.
+
+Connect To Remote Node
+----------------------
+
+See the dedicated guide under :ref:`remote node <remotenode>` to configure Bit
+to use a remote Bitcoin node instead of relying on web APIs for blockchain
+interaction.
 
 .. _satoshi: https://en.bitcoin.it/wiki/Satoshi_(unit)
 .. _blockchain: https://en.bitcoin.it/wiki/Block_chain

--- a/docs/source/guide/remotenode.rst
+++ b/docs/source/guide/remotenode.rst
@@ -8,8 +8,8 @@ possible to connect to a remote Bitcoin Core node. Bitcoin Core however is not
 meant as a full-fledged blockchain explorer and does only keep track of
 addresses associated with its wallet.
 
-Transaction Database Index and `txindex`
-----------------------------------------
+Transaction Database Index and ``txindex``
+------------------------------------------
 
 By default Bitcoin Core does not maintain any transaction-level data except for
 those transactions
@@ -17,7 +17,7 @@ those transactions
 - pertinent to addresses in your wallet
 - pertinent to your "watch-only" addresses
 
-If querying arbitrary transactions is important then the option `txindex` must
+If querying arbitrary transactions is important then the option ``txindex`` must
 be set to true (1) inside the Bitcoin Core configuration file, see
 `Running Bitcoin`_. Setting this option does not allow querying arbitrary data
 on addresses, which are still required to be present in the wallet for Bitcoin
@@ -30,8 +30,8 @@ To use Bitcoin Core as a remote node it must accept remote procedure call (RPC)
 methods from the host running Bit. A username and password for the RPC must be
 defined inside the Bitcoin Core configuration file.
 
-Adding a RPC user and password can be done with the `rpcauth` option that uses a
-hashed password. The field comes in the format: `<USERNAME>:<SALT>$<HASH>`. A
+Adding a RPC user and password can be done with the ``rpcauth`` option that uses a
+hashed password. The field comes in the format: ``<USERNAME>:<SALT>$<HASH>``. A
 canonical python script is included inside Bitcoin Core's `share/rpcuser`_
 directory. This python script creates such a user/password combination
 (note that you are given the password, you do not get to specify it yourself).
@@ -50,10 +50,10 @@ Run the script, e.g.:
 Note that this option can be specified multiple times.
 
 Finally, make sure that Bitcoin Core will accept RPC methods from the host
-running Bit. The option `rpcallowip=<ip>` allows RPC connections from specified
+running Bit. The option ``rpcallowip=<ip>`` allows RPC connections from specified
 host IP. The default port used to listen to RPC methods can be set with the
-option `rpcport=<port>`; the default values being 8332 for mainnet, 18332 for
-testnet and 18443 for regtest.
+option ``rpcport=<port>``; the default values being ``8332`` for mainnet, ``18332`` for
+testnet and ``18443`` for regtest.
 
 A default configuration file can be found inside the Bitcoin Core directory
 under `share/examples/bitcoin.conf`_.
@@ -86,7 +86,7 @@ Bit will poll the node for data on an address using Bitcoin Core's internal
 wallet. An address to poll must therefore first be imported to Bitcoin Core's
 wallet.
 
-We can directly access the Bitcoin Core node's RPC and then use `importaddress`
+We can directly access the Bitcoin Core node's RPC and then use ``importaddress``
 to import a specific address as follows:
 
 .. code-block:: python
@@ -99,12 +99,12 @@ to import a specific address as follows:
     >>> # Import an address to the node's wallet:
     >>> node.importaddress(key.segwit_address, "optional-label", False)
 
-You can read more about the RPC `importaddress` [here](https://bitcoincore.org/en/doc/0.18.0/rpc/wallet/importaddress/).
+You can read more about the RPC ``importaddress`` `here <https://bitcoincore.org/en/doc/0.18.0/rpc/wallet/importaddress/>`_.
 
 As we had just created the new address we set the last argument in
-`importaddress` to `False`, which defines that the node will not rescan the
+``importaddress`` to ``False``, which defines that the node will not rescan the
 blockchain for the address as it will not have any transactions yet. If you are
-importing a _used_ address you must set the rescan parameter to `True`, as you
+importing a *used* address you must set the rescan parameter to ``True``, as you
 will otherwise receive incorrect information from your node!
 
 Performing a rescan can take several minutes.

--- a/docs/source/guide/remotenode.rst
+++ b/docs/source/guide/remotenode.rst
@@ -1,0 +1,80 @@
+.. _remotenode:
+
+Using a Remote Bitcoin Core Node
+================================
+
+Instead of using web APIs to interact with the Bitcoin blockchain it is
+possible to connect to a remote Bitcoin Core node. Bitcoin Core however is not
+meant as a full-fledged blockchain explorer and does only keep track of
+addresses associated with its wallet.
+
+Transaction Database Index and `txindex`
+----------------------------------------
+
+By default Bitcoin Core does not maintain any transaction-level data except for
+those transactions
+- in the mempool or relay set
+- pertinent to addresses in your wallet
+- pertinent to your "watch-only" addresses
+
+If querying arbitrary transactions is important then the option `txindex` must
+be set to true (1) inside the Bitcoin Core configuration file, see
+`Running Bitcoin`_. Setting this option does not allow querying arbitrary data
+on addresses, which are still required to be present in the wallet for Bitcoin
+Core to be fetched.
+
+Configuring Bitcoin Core
+------------------------
+
+To use Bitcoin Core as a remote node it must accept remote procedure call (RPC)
+methods from the host running Bit. A username and password for the RPC must be
+defined inside the Bitcoin Core configuration file.
+
+Adding a RPC user and password can be done with the `rpcauth` option that uses a
+hashed password. The field comes in the format: `<USERNAME>:<SALT>$<HASH>`. A
+canonical python script is included inside Bitcoin Core's `share/rpcuser`_
+directory. This python script creates such a user/password combination
+(note that you are given the password, you do not get to specify it yourself).
+
+Run the script, e.g.:
+
+.. code-block:: python
+
+    >>> python ./rpcuser.py username
+    String to be appended to bitcoin.conf:
+    rpcauth=username:a14191e6892facf70686a397b126423$ddd6f7480817bd6f8083a2e07e24b93c4d74e667f3a001df26c5dd0ef5eafd0d
+    Your password:
+    VX3z87LBVc_X7NBLABLABLABLA
+
+
+Note that this option can be specified multiple times.
+
+Finally, make sure that Bitcoin Core will accept RPC methods from the host
+running Bit. The option `rpcallowip=<ip>` allows RPC connections from specified
+host IP. The default port used to listen to RPC methods can be set with the
+option `rpcport=<port>`; the default values being 8332 for mainnet, 18332 for
+testnet and 18443 for regtest.
+
+A default configuration file can be found inside the Bitcoin Core directory
+under `share/examples/bitcoin.conf`_.
+
+Connecting To The Node
+----------------------
+
+Connecting to a remote Bitcoin Core node from Bit is straight forward. It can be
+done by calling :func:`~bit.network.services.NetworkAPI.connect_to_node`, e.g.
+
+.. code-block:: python
+
+    >>> from bit.network import NetworkAPI
+    >>> NetworkAPI.connect_to_node(user='username', password='password', host='localhost', port=18443, use_https=False, testnet=True)
+
+It is possible to connect to both a testnet and mainnet node by calling
+:func:`~bit.network.services.NetworkAPI.connect_to_node` twice with the
+arguments accordingly.
+
+Using The Remote Bitcoin Core Node
+----------------------------------
+
+After connecting to the remote node all API calls done by
+:class:`~bit.network.services.NetworkAPI` are seamlessly redirected to it.

--- a/docs/source/guide/remotenode.rst
+++ b/docs/source/guide/remotenode.rst
@@ -78,3 +78,33 @@ Using The Remote Bitcoin Core Node
 
 After connecting to the remote node all API calls done by
 :class:`~bit.network.services.NetworkAPI` are seamlessly redirected to it.
+
+Adding An Address To The Internal Wallet Of A Node
+--------------------------------------------------
+
+Bit will poll the node for data on an address using Bitcoin Core's internal
+wallet. An address to poll must therefore first be imported to Bitcoin Core's
+wallet.
+
+We can directly access the Bitcoin Core node's RPC and then use `importaddress`
+to import a specific address as follows:
+
+.. code-block:: python
+
+    >>> import bit
+    >>> from bit.network import NetworkAPI
+    >>> # Get the `node` object for direct access:
+    >>> node = NetworkAPI.connect_to_node(user='username', password='password', host='localhost', port=18443, use_https=False, testnet=True)
+    >>> key = bit.PrivateKeyTestnet()
+    >>> # Import an address to the node's wallet:
+    >>> node.importaddress(key.segwit_address, "optional-label", False)
+
+You can read more about the RPC `importaddress` [here](https://bitcoincore.org/en/doc/0.18.0/rpc/wallet/importaddress/).
+
+As we had just created the new address we set the last argument in
+`importaddress` to `False`, which defines that the node will not rescan the
+blockchain for the address as it will not have any transactions yet. If you are
+importing a _used_ address you must set the rescan parameter to `True`, as you
+will otherwise receive incorrect information from your node!
+
+Performing a rescan can take several minutes.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,7 +62,7 @@ Features
 - Fully supports 25 different currencies
 - First class support for storing data in the blockchain
 - Deterministic signatures via RFC 6979
-- Access to the blockchain (and testnet chain) through multiple APIs for redundancy
+- Access to the blockchain (and testnet chain) through multiple APIs for redundancy or a remote Bitcoin node
 - Exchange rate API, with optional caching
 - Optimal transaction fee API, with optional caching
 - Compressed public keys by default

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'cli': ('appdirs', 'click', 'privy', 'tinydb'),
         'cache': ('lmdb', ),
     },
-    tests_require=['pytest'],
+    tests_require=['pytest', 'requests_mock'],
 
     packages=find_packages(),
     entry_points={

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -159,10 +159,14 @@ class MockRPCMethod(RPCMethod):
                 }]
 
         if self._rpc_method == "sendrawtransaction":
-            assert args[0] == "01000000000000000000"
+            assert args[0] == "01000000000000000000" or args[0] == "00000000000000000000"
+
+            if args[0] == "00000000000000000000":
+                raise bit.exceptions.BitcoinNodeException()
+
             return ""
 
-        raise AttributeError('called unsupported RPC method %s', self._rpc_method)
+        raise AttributeError('called unsupported RPC method %s', self._rpc_method)  # pragma: no cover
 
 
 class TestNetworkAPI:
@@ -481,11 +485,19 @@ class TestRPCHost:
 
     def test_broadcast_tx(self):
         node = MockRPCHost("user", "password", "host", 8333, True)
-        node.broadcast_tx("01000000000000000000")
+        assert node.broadcast_tx("01000000000000000000") is True
 
-    def test_broadcast_tx_testnet(self):
+    def test_broadcast_tx_fail(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert node.broadcast_tx("00000000000000000000") is False
+
+    def test_broadcast_tx_test(self):
         node = MockRPCHost("user", "password", "host", 18443, False)
-        node.broadcast_tx_testnet("01000000000000000000")
+        assert node.broadcast_tx_testnet("01000000000000000000") is True
+
+    def test_broadcast_tx_test_fail(self):
+        node = MockRPCHost("user", "password", "host", 18443, False)
+        assert node.broadcast_tx_testnet("00000000000000000000") is False
 
 
 class TestRPCMethod(unittest.TestCase):

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -542,6 +542,19 @@ class TestRPCMethod(unittest.TestCase):
         with pytest.raises(bit.exceptions.BitcoinNodeException):
             method()
 
+    @requests_mock.mock()
+    def test_call_fails_unsupported_command(self, m):
+        method = RPCMethod("some_rpc_method", RPCHost("user", "password", "host", 18443, False))
+        m.register_uri(
+            'POST',
+            'http://user:password@host:18443/',
+            json=json.loads('{"result": false, "error": true}'),
+            status_code=200,
+            reason="testing failing return value"
+        )
+        with pytest.raises(bit.exceptions.BitcoinNodeException):
+            method()
+
     def test_call_fails_connection(self):
         method = RPCMethod("some_rpc_method", RPCHost("user", "password", "some_invalid_host", 18443, False))
         with pytest.raises(ConnectionError):

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -1,8 +1,13 @@
 import pytest
+import requests
+import json
+import unittest
+import requests_mock
 
 import bit
 from bit.network.services import (
-    BitpayAPI, BlockchainAPI, NetworkAPI, SmartbitAPI, set_service_timeout
+    RPCHost, RPCMethod, BitpayAPI, BlockchainAPI, NetworkAPI, SmartbitAPI,
+    set_service_timeout
 )
 from tests.utils import (
     catch_errors_raise_warnings, decorate_methods, raise_connection_error
@@ -53,6 +58,111 @@ class MockBackend(NetworkAPI):
     GET_TRANSACTIONS_TEST = [raise_connection_error]
     GET_TRANSACTION_BY_ID_TEST = [raise_connection_error]
     GET_UNSPENT_TEST = [raise_connection_error]
+
+
+class MockRPCHost(RPCHost):
+    def __getattr__(self, rpc_method):
+        return MockRPCMethod(rpc_method, None)
+
+
+class MockRPCMethod(RPCMethod):
+    def __call__(self, *args):
+        if self._rpc_method == "getreceivedbyaddress":
+            assert (
+                args[0] == MAIN_ADDRESS_USED1
+                or args[0] == TEST_ADDRESS_USED2
+                or args[0] == MAIN_ADDRESS_UNUSED
+                or args[0] == TEST_ADDRESS_UNUSED
+            )
+            assert args[1] == 0
+
+            if args[0] in (MAIN_ADDRESS_USED1, TEST_ADDRESS_USED2):
+                return 1.23456789
+            return 0
+
+        if self._rpc_method == "listreceivedbyaddress":
+            assert args[0] == 0
+            assert args[1] is True
+            assert args[2] is True
+            assert (
+                args[3] == MAIN_ADDRESS_USED1
+                or args[3] == TEST_ADDRESS_USED2
+                or args[3] == MAIN_ADDRESS_UNUSED
+                or args[3] == TEST_ADDRESS_UNUSED
+            )
+
+            if args[3] == MAIN_ADDRESS_USED1:
+                return [{
+                    "involvesWatchonly": True,
+                    "address": "1L2JsXHPMYuAa9ugvHGLwkdstCPUDemNCf",
+                    "amount": 1.23456789,
+                    "confirmations": 0,
+                    "label": "",
+                    "txids": [
+                      "381f1605dd927151fbfac2e88608464414fa5b01bd6298cd1e2d9d991907aa9e",
+                      "6e05c708d88cc5bf0f1533938c969de2cc48f438b0ae28ce89fefbaa1938185a"
+                    ]}]
+            elif args[3] == TEST_ADDRESS_USED2:
+                return [{
+                    "involvesWatchonly": True,
+                    "address": "mmvP3mTe53qxHdPqXEvdu8WdC7GfQ2vmx5",
+                    "amount": 1.23456789,
+                    "confirmations": 0,
+                    "label": "",
+                    "txids": [
+                      "ff2b4641481f1ee553ba2c9f02f413a86f70240c35b5aee554f84e3efee93292",
+                      "ef9bd3ac4eacc60a16117eaca0631bbef673eb8a71084de4b9ada3317f7895e9",
+                      "ff2b4641481f1ee553ba2c9f02f413a86f70240c35b5aee554f84e3efee93290"
+                    ]}]
+            return []
+
+        if self._rpc_method == "getrawtransaction":
+            assert args[0] == MAIN_TX_VALID or args[0] == TEST_TX_VALID
+            assert args[1] is False
+            return True
+
+        if self._rpc_method == "listunspent":
+            assert args[0] == 0
+            assert args[1] == 9999999
+            assert (
+                args[2] == [MAIN_ADDRESS_USED1]
+                or args[2] == [TEST_ADDRESS_USED2]
+                or args[2] == [MAIN_ADDRESS_UNUSED]
+                or args[2] == [TEST_ADDRESS_UNUSED]
+            )
+
+            if args[2][0] in (MAIN_ADDRESS_UNUSED, TEST_ADDRESS_UNUSED):
+                return []
+            return [{
+                "txid": "381f1605dd927151fbfac2e88608464414fa5b01bd6298cd1e2d9d991907aa9e",
+                "vout": 0,
+                "address": MAIN_ADDRESS_USED1,
+                "label": "",
+                "scriptPubKey": "a9142df37714a79eacad089a41481a6a3e400d39a54687",
+                "amount": 1.23456789,
+                "confirmations": 0,
+                "spendable": False,
+                "solvable": False,
+                "safe": True
+                },
+                {
+                "txid": "ef9bd3ac4eacc60a16117eaca0631bbef673eb8a71084de4b9ada3317f7895e9",
+                "vout": 1,
+                "address": MAIN_ADDRESS_USED1,
+                "label": "",
+                "scriptPubKey": "a9142df37714a79eacad089a41481a6a3e400d39a54687",
+                "amount": 1.23456789,
+                "confirmations": 0,
+                "spendable": False,
+                "solvable": False,
+                "safe": True
+                }]
+
+        if self._rpc_method == "sendrawtransaction":
+            assert args[0] == "01000000000000000000"
+            return ""
+
+        raise AttributeError('called unsupported RPC method %s', self._rpc_method)
 
 
 class TestNetworkAPI:
@@ -280,3 +390,153 @@ class TestSmartbitAPI:
 
     def test_get_unspent_test_unused(self):
         assert len(SmartbitAPI.get_unspent_testnet(TEST_ADDRESS_UNUSED)) == 0
+
+
+class TestRPCHost:
+    def test_init(self):
+        node = RPCHost("user", "password", "host", 8333, True)
+        assert node._url == "https://user:password@host:8333/"
+        assert isinstance(node._session, requests.Session)
+        assert node._session.verify is True
+        assert node._headers == {"content-type": "application/json"}
+
+        node = RPCHost("usr", "pass", "other", 18443, False)
+        assert node._url == "http://usr:pass@other:18443/"
+        assert isinstance(node._session, requests.Session)
+        assert node._session.verify is False
+        assert node._headers == {"content-type": "application/json"}
+
+    def test_rpc_method_call(self):
+        assert isinstance(RPCHost.__getattr__(None, "rpc_method"), RPCMethod)
+        assert RPCHost.__getattr__(None, "rpc_method")._rpc_method == "rpc_method"
+        assert RPCHost.__getattr__(None, "rpc_method")._host is None
+
+    def test_get_balance_return_type(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert isinstance(node.get_balance(MAIN_ADDRESS_USED1), int)
+
+    def test_get_balance_main_unused(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert node.get_balance(MAIN_ADDRESS_UNUSED) == 0
+
+    def test_get_balance_test_unused(self):
+        node = MockRPCHost("user", "password", "host", 18443, False)
+        assert node.get_balance_testnet(TEST_ADDRESS_UNUSED) == 0
+
+    def test_get_balance_main_used(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert node.get_balance(MAIN_ADDRESS_USED1) == 123456789
+
+    def test_get_balance_test_used(self):
+        node = MockRPCHost("user", "password", "host", 18443, False)
+        assert node.get_balance_testnet(TEST_ADDRESS_USED2) == 123456789
+
+    def test_get_transactions_return_type(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert iter(node.get_transactions(MAIN_ADDRESS_USED1))
+
+    def test_get_transactions_main_used(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert len(node.get_transactions(MAIN_ADDRESS_USED1)) == 2
+
+    def test_get_transactions_main_unused(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert len(node.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
+
+    def test_get_transactions_test_used(self):
+        node = MockRPCHost("user", "password", "host", 18443, False)
+        assert len(node.get_transactions_testnet(TEST_ADDRESS_USED2)) == 3
+
+    def test_get_transactions_test_unused(self):
+        node = MockRPCHost("user", "password", "host", 18443, False)
+        assert len(node.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
+
+    def test_get_transaction_by_id_main(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert node.get_transaction_by_id(MAIN_TX_VALID)
+
+    def test_get_transaction_by_id_test(self):
+        node = MockRPCHost("user", "password", "host", 18443, False)
+        assert node.get_transaction_by_id_testnet(TEST_TX_VALID)
+
+    def test_get_unspent_return_type(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert iter(node.get_unspent(MAIN_ADDRESS_USED1))
+
+    def test_get_unspent_used(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert len(node.get_unspent(MAIN_ADDRESS_USED1)) == 2
+
+    def test_get_unspent_unused(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        assert len(node.get_unspent(MAIN_ADDRESS_UNUSED)) == 0
+
+    def test_get_unspent_test_used(self):
+        node = MockRPCHost("user", "password", "host", 18443, False)
+        assert len(node.get_unspent_testnet(TEST_ADDRESS_USED2)) == 2
+
+    def test_get_unspent_test_unused(self):
+        node = MockRPCHost("user", "password", "host", 18443, False)
+        assert len(node.get_unspent_testnet(TEST_ADDRESS_UNUSED)) == 0
+
+    def test_broadcast_tx(self):
+        node = MockRPCHost("user", "password", "host", 8333, True)
+        node.broadcast_tx("01000000000000000000")
+
+    def test_broadcast_tx_testnet(self):
+        node = MockRPCHost("user", "password", "host", 18443, False)
+        node.broadcast_tx_testnet("01000000000000000000")
+
+
+class TestRPCMethod(unittest.TestCase):
+    def test_init(self):
+        method = RPCMethod("some_rpc_method", None)
+        assert method._rpc_method == "some_rpc_method"
+        assert method._host is None
+
+    @requests_mock.mock()
+    def test_call_success(self, m):
+        method = RPCMethod("some_rpc_method", RPCHost("user", "password", "host", 18443, False))
+        m.register_uri(
+            'POST',
+            'http://user:password@host:18443/',
+            request_headers={"content-type": "application/json"},
+            additional_matcher=lambda req: req.text == json.dumps({"method": "some_rpc_method", "params": ["arg1", 2], "jsonrpc": "2.0"}),
+            json=json.loads('{"result": true, "error": null}'),
+            status_code=200
+        )
+        self.assertEqual(method("arg1", 2), True)
+
+        method = RPCMethod("other_rpc_method", RPCHost("user", "password", "host", 18443, False))
+        m.register_uri(
+            'POST',
+            'http://user:password@host:18443/',
+            request_headers={"content-type": "application/json"},
+            additional_matcher=lambda req: req.text == json.dumps({"method": "other_rpc_method", "params": [[0], "arg2", "arg3"], "jsonrpc": "2.0"}),
+            json=json.loads('{"result": true, "error": null}'),
+            status_code=500
+        )
+        self.assertEqual(method([0], "arg2", "arg3"), True)
+
+    @requests_mock.mock()
+    def test_call_fails_status_code(self, m):
+        method = RPCMethod("some_rpc_method", RPCHost("user", "password", "host", 18443, False))
+        m.register_uri(
+            'POST',
+            'http://user:password@host:18443/',
+            status_code=201,
+            reason="testing failing status code"
+        )
+        with pytest.raises(bit.exceptions.BitcoinNodeException):
+            method()
+
+    def test_call_fails_connection(self):
+        method = RPCMethod("some_rpc_method", RPCHost("user", "password", "some_invalid_host", 18443, False))
+        with pytest.raises(ConnectionError):
+            method()
+
+    def test_subcall(self):
+        method = RPCMethod("some_rpc_method", None)
+        sub_method = method.sub_cmd
+        assert sub_method._rpc_method == "some_rpc_method.sub_cmd"
+        assert sub_method._host is None

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -234,6 +234,52 @@ class TestNetworkAPI:
         with pytest.raises(ConnectionError):
             MockBackend.get_unspent_testnet(TEST_ADDRESS_USED2)
 
+    def test_connect_to_node_main(self):
+        # Copy the NetworkAPI class as to not override it
+        class n(NetworkAPI):
+            pass
+
+        n.connect_to_node(user="user", password="password")
+        assert sum(call.__self__ == RPCHost("user", "password", "localhost", 8332, False) for call in n.GET_BALANCE_MAIN) == 1
+        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_MAIN) == 0
+        assert sum(call.__self__ == RPCHost("user", "password", "localhost", 8332, False) for call in n.GET_TRANSACTIONS_MAIN) == 1
+        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_MAIN) == 0
+        assert sum(call.__self__ == RPCHost("user", "password", "localhost", 8332, False) for call in n.GET_TRANSACTION_BY_ID_MAIN) == 1
+        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_MAIN) == 0
+        assert sum(call.__self__ == RPCHost("user", "password", "localhost", 8332, False) for call in n.GET_UNSPENT_MAIN) == 1
+        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_MAIN) == 0
+        assert sum(call.__self__ == RPCHost("user", "password", "localhost", 8332, False) for call in n.BROADCAST_TX_MAIN) == 1
+        assert sum(not isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_MAIN) == 0
+
+        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_TEST) == 0
+        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_TEST) == 0
+        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_TEST) == 0
+        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_TEST) == 0
+        assert sum(isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_TEST) == 0
+
+    def test_connect_to_node_test(self):
+        # Copy the NetworkAPI class as to not override it
+        class n(NetworkAPI):
+            pass
+
+        n.connect_to_node(user="usr", password="pass", host="host", port=18443, use_https=True, testnet=True)
+        assert sum(call.__self__ == RPCHost("usr", "pass", "host", 18443, True) for call in n.GET_BALANCE_TEST) == 1
+        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_TEST) == 0
+        assert sum(call.__self__ == RPCHost("usr", "pass", "host", 18443, True) for call in n.GET_TRANSACTIONS_TEST) == 1
+        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_TEST) == 0
+        assert sum(call.__self__ == RPCHost("usr", "pass", "host", 18443, True) for call in n.GET_TRANSACTION_BY_ID_TEST) == 1
+        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_TEST) == 0
+        assert sum(call.__self__ == RPCHost("usr", "pass", "host", 18443, True) for call in n.GET_UNSPENT_TEST) == 1
+        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_TEST) == 0
+        assert sum(call.__self__ == RPCHost("usr", "pass", "host", 18443, True) for call in n.BROADCAST_TX_TEST) == 1
+        assert sum(not isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_TEST) == 0
+
+        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_MAIN) == 0
+        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_MAIN) == 0
+        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_MAIN) == 0
+        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_MAIN) == 0
+        assert sum(isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_MAIN) == 0
+
 
 @decorate_methods(catch_errors_raise_warnings, NetworkAPI.IGNORED_ERRORS)
 class TestBitpayAPI:

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -27,6 +27,7 @@ MAIN_TX_VALID = '6e05c708d88cc5bf0f1533938c969de2cc48f438b0ae28ce89fefbaa1938185
 TEST_TX_VALID = 'ff2b4641481f1ee553ba2c9f02f413a86f70240c35b5aee554f84e3efee93292'
 TX_INVALID = 'ff2b4641481f1ee553ba2c9f02f413a86f70240c35b5aee554f84e3efee93290'
 
+
 def all_items_common(seq):
     initial_set = set(seq[0])
     intersection_lengths = [len(set(s) & initial_set) for s in seq]
@@ -36,6 +37,11 @@ def all_items_common(seq):
 def all_items_equal(seq):
     initial_item = seq[0]
     return all(item == initial_item for item in seq if item is not None)
+
+
+def both_rpchosts_equal(host1, host2):
+    return host1._url == host2._url and host1._headers == host2._headers
+
 
 def test_set_service_timeout():
     original = bit.network.services.DEFAULT_TIMEOUT
@@ -240,22 +246,22 @@ class TestNetworkAPI:
             pass
 
         n.connect_to_node(user="user", password="password")
-        assert sum(call.__self__ == RPCHost("user", "password", "localhost", 8332, False) for call in n.GET_BALANCE_MAIN) == 1
-        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_MAIN) == 0
-        assert sum(call.__self__ == RPCHost("user", "password", "localhost", 8332, False) for call in n.GET_TRANSACTIONS_MAIN) == 1
-        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_MAIN) == 0
-        assert sum(call.__self__ == RPCHost("user", "password", "localhost", 8332, False) for call in n.GET_TRANSACTION_BY_ID_MAIN) == 1
-        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_MAIN) == 0
-        assert sum(call.__self__ == RPCHost("user", "password", "localhost", 8332, False) for call in n.GET_UNSPENT_MAIN) == 1
-        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_MAIN) == 0
-        assert sum(call.__self__ == RPCHost("user", "password", "localhost", 8332, False) for call in n.BROADCAST_TX_MAIN) == 1
-        assert sum(not isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_MAIN) == 0
+        assert sum(both_rpchosts_equal(call.__self__, RPCHost("user", "password", "localhost", 8332, False)) for call in n.GET_BALANCE_MAIN) == 1
+        assert all(isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_MAIN)
+        assert sum(both_rpchosts_equal(call.__self__, RPCHost("user", "password", "localhost", 8332, False)) for call in n.GET_TRANSACTIONS_MAIN) == 1
+        assert all(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_MAIN)
+        assert sum(both_rpchosts_equal(call.__self__, RPCHost("user", "password", "localhost", 8332, False)) for call in n.GET_TRANSACTION_BY_ID_MAIN) == 1
+        assert all(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_MAIN)
+        assert sum(both_rpchosts_equal(call.__self__, RPCHost("user", "password", "localhost", 8332, False)) for call in n.GET_UNSPENT_MAIN) == 1
+        assert all(isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_MAIN)
+        assert sum(both_rpchosts_equal(call.__self__, RPCHost("user", "password", "localhost", 8332, False)) for call in n.BROADCAST_TX_MAIN) == 1
+        assert all(isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_MAIN)
 
-        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_TEST) == 0
-        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_TEST) == 0
-        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_TEST) == 0
-        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_TEST) == 0
-        assert sum(isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_TEST) == 0
+        assert all(not isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_TEST)
+        assert all(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_TEST)
+        assert all(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_TEST)
+        assert all(not isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_TEST)
+        assert all(not isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_TEST)
 
     def test_connect_to_node_test(self):
         # Copy the NetworkAPI class as to not override it
@@ -263,22 +269,22 @@ class TestNetworkAPI:
             pass
 
         n.connect_to_node(user="usr", password="pass", host="host", port=18443, use_https=True, testnet=True)
-        assert sum(call.__self__ == RPCHost("usr", "pass", "host", 18443, True) for call in n.GET_BALANCE_TEST) == 1
-        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_TEST) == 0
-        assert sum(call.__self__ == RPCHost("usr", "pass", "host", 18443, True) for call in n.GET_TRANSACTIONS_TEST) == 1
-        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_TEST) == 0
-        assert sum(call.__self__ == RPCHost("usr", "pass", "host", 18443, True) for call in n.GET_TRANSACTION_BY_ID_TEST) == 1
-        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_TEST) == 0
-        assert sum(call.__self__ == RPCHost("usr", "pass", "host", 18443, True) for call in n.GET_UNSPENT_TEST) == 1
-        assert sum(not isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_TEST) == 0
-        assert sum(call.__self__ == RPCHost("usr", "pass", "host", 18443, True) for call in n.BROADCAST_TX_TEST) == 1
-        assert sum(not isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_TEST) == 0
+        assert sum(both_rpchosts_equal(call.__self__, RPCHost("usr", "pass", "host", 18443, True)) for call in n.GET_BALANCE_TEST) == 1
+        assert all(isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_TEST)
+        assert sum(both_rpchosts_equal(call.__self__, RPCHost("usr", "pass", "host", 18443, True)) for call in n.GET_TRANSACTIONS_TEST) == 1
+        assert all(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_TEST)
+        assert sum(both_rpchosts_equal(call.__self__, RPCHost("usr", "pass", "host", 18443, True)) for call in n.GET_TRANSACTION_BY_ID_TEST) == 1
+        assert all(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_TEST)
+        assert sum(both_rpchosts_equal(call.__self__, RPCHost("usr", "pass", "host", 18443, True)) for call in n.GET_UNSPENT_TEST) == 1
+        assert all(isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_TEST)
+        assert sum(both_rpchosts_equal(call.__self__, RPCHost("usr", "pass", "host", 18443, True)) for call in n.BROADCAST_TX_TEST) == 1
+        assert all(isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_TEST)
 
-        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_MAIN) == 0
-        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_MAIN) == 0
-        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_MAIN) == 0
-        assert sum(isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_MAIN) == 0
-        assert sum(isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_MAIN) == 0
+        assert all(not isinstance(call.__self__, RPCHost) for call in n.GET_BALANCE_MAIN)
+        assert all(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTIONS_MAIN)
+        assert all(not isinstance(call.__self__, RPCHost) for call in n.GET_TRANSACTION_BY_ID_MAIN)
+        assert all(not isinstance(call.__self__, RPCHost) for call in n.GET_UNSPENT_MAIN)
+        assert all(not isinstance(call.__self__, RPCHost) for call in n.BROADCAST_TX_MAIN)
 
 
 @decorate_methods(catch_errors_raise_warnings, NetworkAPI.IGNORED_ERRORS)

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     codecov
     coverage
     pytest
+    requests_mock
 commands =
     python setup.py --quiet clean develop
     coverage run --parallel-mode -m pytest


### PR DESCRIPTION
This PR adds a method allowing the `NetworkAPI` to connect to a remote Bitcoin node instead of relying on web APIs. It is marked as a work-in-progress to allow testing, code improvements and test cases to be added. 

It has been implemented in a way to minimize changes to the codebase and to not break already existing tests. Any suggestions however on how to better connect the new class `bit.network.services.RPCHost` with the `NetworkAPI` is welcome! Right now inside `NetworkAPI` it simply overrides its web-API values using the `RPCHost` instead.

This implementation also allows to connect to two different Bitcoin nodes: one for mainnet and one for testnet; and keeps them separate.

# Example code
```python
import bit

# To connect to a remote Bitcoin node:
from bit.network import NetworkAPI
NetworkAPI.connect_to_node(user='user', password='password', host='localhost', port='18443', use_https=False, testnet=True)

# We could additionally choose to connect to some mainnet node:
NetworkAPI.connect_to_node(user='user', password='password', host='domain', port='8332', use_https=True, testnet=False)

# Do some bit stuff...
k_test = bit.PrivateKeyTestnet()
k_test.get_unspents()  # will use the testnet node for API
k_main = bit.PrivateKey()
k_main.get_unspents()  # will use the mainnet node for API
# ...
```

# Remarks
Bitcoin Core is not a blockchain explorer and thus only keeps full track of addresses in its wallet! Therefore to use it as a remote node all addresses generated with Bit and that should be tracked must be added as (watch-only) addresses to Bitcoin Core as follows:
```
>>> bitcoin-cli importaddress "WATCH_ONLY_ADDRESS"
```
See [importaddress](https://bitcoincore.org/en/doc/0.18.0/rpc/wallet/importaddress/) for more details.

It may be useful to add a helper function that can add generated Bit addresses to the Bitcoin Core wallet.

## Bitcoin Core RPC behaves particular with regard to coinbase transactions
Coinbase transactions directly received inside a Bitcoin Core wallet address will as expected be returned as a list of `Unspent` objects when using `PrivateKey().get_unused()`. However, they will _not_ show up when using `PrivateKey().get_transactions()`. A fix would be to rewrite the `RPCHost` method `get_transactions` to use the RPC method `listsinceblock`, which returns all transactions associated to the Bitcoin Core wallet but hence also requires Bit to filter them by addresses. As this is an edge case and wasteful for big wallets it has been ignored (for now).
See the discussion [here](https://bitcoin.stackexchange.com/questions/36693/how-can-i-list-my-mined-coins-using-rpc-and-spend-them).


# TODOs
 * ~~Add test cases~~
 * ~~Add helper function adding addresses as watch-only to the node~~
 * ~~Add documentation~~
 * ~~Check SSL to allow self-signed certs (`rpcssl` is deprecated, see https://bitcoin.org/en/release/v0.12.0#rpc-ssl-support-dropped)~~