### PR TITLE
Fixes testing network APIs + adds 3 new APIs (btc.com, blockchair.com and blockstream.info)

### DIFF
--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -8,18 +8,27 @@ import bit
 from bit.network.services import (
     RPCHost,
     RPCMethod,
-    BitpayAPI,
-    BlockchainAPI,
     NetworkAPI,
+    BitcoreAPI,
+    BlockchainAPI,
     SmartbitAPI,
+    BlockstreamAPI,
+    BlockchairAPI,
+    BTCcomAPI,
     set_service_timeout,
 )
-from tests.utils import catch_errors_raise_warnings, decorate_methods, raise_connection_error
+from tests.utils import (
+    catch_errors_raise_warnings,
+    decorate_methods,
+    raise_connection_error,
+    check_not_all_raise_errors,
+)
 
 from bit.transaction import calc_txid
 
 MAIN_ADDRESS_USED1 = '1L2JsXHPMYuAa9ugvHGLwkdstCPUDemNCf'
 MAIN_ADDRESS_USED2 = '17SkEw2md5avVNyYgj6RiXuQKNwkXaxFyQ'
+MAIN_ADDRESS_USED3 = '1CounterpartyXXXXXXXXXXXXXXXUWLpVr'
 MAIN_ADDRESS_UNUSED = '1DvnoW4vsXA1H9KDgNiMqY7iNkzC187ve1'
 TEST_ADDRESS_USED1 = 'n2eMqTT929pb1RDNuqEnxdaLau1rxy3efi'
 TEST_ADDRESS_USED2 = 'mmvP3mTe53qxHdPqXEvdu8WdC7GfQ2vmx5'
@@ -29,6 +38,8 @@ TEST_ADDRESS_UNUSED = 'mp1xDKvvZ4yd8h9mLC4P76syUirmxpXhuk'
 MAIN_TX_VALID = '6e05c708d88cc5bf0f1533938c969de2cc48f438b0ae28ce89fefbaa1938185a'
 TEST_TX_VALID = 'ff2b4641481f1ee553ba2c9f02f413a86f70240c35b5aee554f84e3efee93292'
 TX_INVALID = 'ff2b4641481f1ee553ba2c9f02f413a86f70240c35b5aee554f84e3efee93290'
+
+set_service_timeout(30)
 
 
 def all_items_common(seq):
@@ -188,7 +199,7 @@ class MockRPCMethod(RPCMethod):
 
 class TestNetworkAPI:
     def test_get_balance_main_equal(self):
-        results = [call(MAIN_ADDRESS_USED2) for call in NetworkAPI.GET_BALANCE_MAIN]
+        results = check_not_all_raise_errors(NetworkAPI.GET_BALANCE_MAIN, NetworkAPI.IGNORED_ERRORS)(MAIN_ADDRESS_USED2)
         assert all(result == results[0] for result in results)
 
     def test_get_balance_main_failure(self):
@@ -196,7 +207,7 @@ class TestNetworkAPI:
             MockBackend.get_balance(MAIN_ADDRESS_USED2)
 
     def test_get_balance_test_equal(self):
-        results = [call(TEST_ADDRESS_USED2) for call in NetworkAPI.GET_BALANCE_TEST]
+        results = check_not_all_raise_errors(NetworkAPI.GET_BALANCE_TEST, NetworkAPI.IGNORED_ERRORS)(TEST_ADDRESS_USED2)
         assert all(result == results[0] for result in results)
 
     def test_get_balance_test_failure(self):
@@ -204,39 +215,47 @@ class TestNetworkAPI:
             MockBackend.get_balance_testnet(TEST_ADDRESS_USED2)
 
     def test_get_transactions_main_equal(self):
-        results = [call(MAIN_ADDRESS_USED1)[:100] for call in NetworkAPI.GET_TRANSACTIONS_MAIN]
-        assert all_items_common(results)
+        results = check_not_all_raise_errors(NetworkAPI.GET_TRANSACTIONS_MAIN, NetworkAPI.IGNORED_ERRORS)(
+            MAIN_ADDRESS_USED1
+        )
+        assert all_items_common([r[:100] for r in results])
 
     def test_get_transactions_main_failure(self):
         with pytest.raises(ConnectionError):
             MockBackend.get_transactions(MAIN_ADDRESS_USED1)
 
     def test_get_transactions_test_equal(self):
-        results = [call(TEST_ADDRESS_USED2)[:100] for call in NetworkAPI.GET_TRANSACTIONS_TEST]
-        assert all_items_common(results)
+        results = check_not_all_raise_errors(NetworkAPI.GET_TRANSACTIONS_TEST, NetworkAPI.IGNORED_ERRORS)(
+            TEST_ADDRESS_USED2
+        )
+        assert all_items_common([r[:100] for r in results])
 
     def test_get_transactions_test_failure(self):
         with pytest.raises(ConnectionError):
             MockBackend.get_transactions_testnet(TEST_ADDRESS_USED2)
 
     def test_get_transaction_by_id_main_equal(self):
-        results = [calc_txid(call(MAIN_TX_VALID)) for call in NetworkAPI.GET_TRANSACTION_BY_ID_MAIN]
-        assert all_items_equal(results)
+        results = check_not_all_raise_errors(NetworkAPI.GET_TRANSACTION_BY_ID_MAIN, NetworkAPI.IGNORED_ERRORS)(
+            MAIN_TX_VALID
+        )
+        assert all_items_equal([calc_txid(r) for r in results])
 
     def test_get_transaction_by_id_main_failure(self):
         with pytest.raises(ConnectionError):
             MockBackend.get_transaction_by_id(MAIN_TX_VALID)
 
     def test_get_transaction_by_id_test_equal(self):
-        results = [calc_txid(call(TEST_TX_VALID)) for call in NetworkAPI.GET_TRANSACTION_BY_ID_TEST]
-        assert all_items_equal(results)
+        results = check_not_all_raise_errors(NetworkAPI.GET_TRANSACTION_BY_ID_TEST, NetworkAPI.IGNORED_ERRORS)(
+            TEST_TX_VALID
+        )
+        assert all_items_equal([calc_txid(r) for r in results])
 
     def test_get_transaction_by_id_test_failure(self):
         with pytest.raises(ConnectionError):
             MockBackend.get_transaction_by_id_testnet(TEST_TX_VALID)
 
     def test_get_unspent_main_equal(self):
-        results = [call(MAIN_ADDRESS_USED2) for call in NetworkAPI.GET_UNSPENT_MAIN]
+        results = check_not_all_raise_errors(NetworkAPI.GET_UNSPENT_MAIN, NetworkAPI.IGNORED_ERRORS)(MAIN_ADDRESS_USED2)
         assert all_items_equal(results)
 
     def test_get_unspent_main_failure(self):
@@ -244,7 +263,7 @@ class TestNetworkAPI:
             MockBackend.get_unspent(MAIN_ADDRESS_USED1)
 
     def test_get_unspent_test_equal(self):
-        results = [call(TEST_ADDRESS_USED3) for call in NetworkAPI.GET_UNSPENT_TEST]
+        results = check_not_all_raise_errors(NetworkAPI.GET_UNSPENT_TEST, NetworkAPI.IGNORED_ERRORS)(TEST_ADDRESS_USED3)
         assert all_items_equal(results)
 
     def test_get_unspent_test_failure(self):
@@ -359,65 +378,36 @@ class TestNetworkAPI:
 
 
 @decorate_methods(catch_errors_raise_warnings, NetworkAPI.IGNORED_ERRORS)
-class TestBitpayAPI:
+class TestBitcoreAPI:
     def test_get_balance_return_type(self):
-        assert isinstance(BitpayAPI.get_balance(MAIN_ADDRESS_USED1), int)
+        assert isinstance(BitcoreAPI.get_balance(MAIN_ADDRESS_USED1), int)
 
     def test_get_balance_main_used(self):
-        assert BitpayAPI.get_balance(MAIN_ADDRESS_USED1) > 0
+        assert BitcoreAPI.get_balance(MAIN_ADDRESS_USED3) > 0
 
     def test_get_balance_main_unused(self):
-        assert BitpayAPI.get_balance(MAIN_ADDRESS_UNUSED) == 0
+        assert BitcoreAPI.get_balance(MAIN_ADDRESS_UNUSED) == 0
 
     def test_get_balance_test_used(self):
-        assert BitpayAPI.get_balance_testnet(TEST_ADDRESS_USED2) > 0
+        assert BitcoreAPI.get_balance_testnet(TEST_ADDRESS_USED2) > 0
 
     def test_get_balance_test_unused(self):
-        assert BitpayAPI.get_balance_testnet(TEST_ADDRESS_UNUSED) == 0
-
-    def test_get_transactions_return_type(self):
-        assert iter(BitpayAPI.get_transactions(MAIN_ADDRESS_USED1))
-
-    def test_get_transactions_main_used(self):
-        assert len(BitpayAPI.get_transactions(MAIN_ADDRESS_USED1)) >= 218
-
-    def test_get_transactions_main_unused(self):
-        assert len(BitpayAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
-
-    def test_get_transactions_test_used(self):
-        assert len(BitpayAPI.get_transactions_testnet(TEST_ADDRESS_USED2)) >= 444
-
-    def test_get_transactions_test_unused(self):
-        assert len(BitpayAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
-
-    def test_get_transaction_by_id_valid(self):
-        tx = BitpayAPI.get_transaction_by_id(MAIN_TX_VALID)
-        assert calc_txid(tx) == MAIN_TX_VALID
-
-    def test_get_transaction_by_id_invalid(self):
-        assert BitpayAPI.get_transaction_by_id(TX_INVALID) == None
-
-    def test_get_transaction_by_id_test_valid(self):
-        tx = BitpayAPI.get_transaction_by_id_testnet(TEST_TX_VALID)
-        assert calc_txid(tx) == TEST_TX_VALID
-
-    def test_get_transaction_by_id_test_invalid(self):
-        assert BitpayAPI.get_transaction_by_id_testnet(TX_INVALID) == None
+        assert BitcoreAPI.get_balance_testnet(TEST_ADDRESS_UNUSED) == 0
 
     def test_get_unspent_return_type(self):
-        assert iter(BitpayAPI.get_unspent(MAIN_ADDRESS_USED1))
+        assert iter(BitcoreAPI.get_unspent(MAIN_ADDRESS_USED1))
 
     def test_get_unspent_main_used(self):
-        assert len(BitpayAPI.get_unspent(MAIN_ADDRESS_USED2)) >= 1
+        assert len(BitcoreAPI.get_unspent(MAIN_ADDRESS_USED3)) >= 2783
 
     def test_get_unspent_main_unused(self):
-        assert len(BitpayAPI.get_unspent(MAIN_ADDRESS_UNUSED)) == 0
+        assert len(BitcoreAPI.get_unspent(MAIN_ADDRESS_UNUSED)) == 0
 
     def test_get_unspent_test_used(self):
-        assert len(BitpayAPI.get_unspent_testnet(TEST_ADDRESS_USED2)) >= 194
+        assert len(BitcoreAPI.get_unspent_testnet(TEST_ADDRESS_USED2)) >= 196
 
     def test_get_unspent_test_unused(self):
-        assert len(BitpayAPI.get_unspent_testnet(TEST_ADDRESS_UNUSED)) == 0
+        assert len(BitcoreAPI.get_unspent_testnet(TEST_ADDRESS_UNUSED)) == 0
 
 
 @decorate_methods(catch_errors_raise_warnings, NetworkAPI.IGNORED_ERRORS)
@@ -426,7 +416,7 @@ class TestBlockchainAPI:
         assert isinstance(BlockchainAPI.get_balance(MAIN_ADDRESS_USED1), int)
 
     def test_get_balance_used(self):
-        assert BlockchainAPI.get_balance(MAIN_ADDRESS_USED1) > 0
+        assert BlockchainAPI.get_balance(MAIN_ADDRESS_USED3) > 0
 
     def test_get_balance_unused(self):
         assert BlockchainAPI.get_balance(MAIN_ADDRESS_UNUSED) == 0
@@ -435,7 +425,7 @@ class TestBlockchainAPI:
         assert iter(BlockchainAPI.get_transactions(MAIN_ADDRESS_USED1))
 
     def test_get_transactions_used(self):
-        assert len(BlockchainAPI.get_transactions(MAIN_ADDRESS_USED1)) >= 218
+        assert len(BlockchainAPI.get_transactions(MAIN_ADDRESS_USED1)) >= 236
 
     def test_get_transactions_unused(self):
         assert len(BlockchainAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
@@ -451,10 +441,172 @@ class TestBlockchainAPI:
         assert iter(BlockchainAPI.get_unspent(MAIN_ADDRESS_USED1))
 
     def test_get_unspent_main_used(self):
-        assert len(BlockchainAPI.get_unspent(MAIN_ADDRESS_USED2)) >= 1
+        # ! BlockchainAPI only supports up to 1000 UTXOs
+        assert len(BlockchainAPI.get_unspent(MAIN_ADDRESS_USED3)) == 1000
 
     def test_get_unspent_main_unused(self):
         assert len(BlockchainAPI.get_unspent(MAIN_ADDRESS_UNUSED)) == 0
+
+
+@decorate_methods(catch_errors_raise_warnings, NetworkAPI.IGNORED_ERRORS)
+class TestBTCcomAPI:
+    def test_get_balance_return_type(self):
+        assert isinstance(BTCcomAPI.get_balance(MAIN_ADDRESS_USED1), int)
+
+    def test_get_balance_used(self):
+        assert BTCcomAPI.get_balance(MAIN_ADDRESS_USED3) > 0
+
+    def test_get_balance_unused(self):
+        assert BTCcomAPI.get_balance(MAIN_ADDRESS_UNUSED) == 0
+
+    def test_get_transactions_return_type(self):
+        assert iter(BTCcomAPI.get_transactions(MAIN_ADDRESS_USED1))
+
+    def test_get_transactions_used(self):
+        assert len(BTCcomAPI.get_transactions(MAIN_ADDRESS_USED1)) >= 236
+
+    def test_get_transactions_unused(self):
+        assert len(BTCcomAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
+
+    def test_get_transaction_by_id_valid(self):
+        tx = BTCcomAPI.get_transaction_by_id(MAIN_TX_VALID)
+        assert calc_txid(tx) == MAIN_TX_VALID
+
+    def test_get_transaction_by_id_invalid(self):
+        assert BTCcomAPI.get_transaction_by_id(TX_INVALID) == None
+
+    def test_get_unspent_return_type(self):
+        assert iter(BTCcomAPI.get_unspent(MAIN_ADDRESS_USED1))
+
+    def test_get_unspent_used(self):
+        assert len(BTCcomAPI.get_unspent(MAIN_ADDRESS_USED3)) >= 2783
+
+    def test_get_unspent_unused(self):
+        assert len(BTCcomAPI.get_unspent(MAIN_ADDRESS_UNUSED)) == 0
+
+
+@decorate_methods(catch_errors_raise_warnings, NetworkAPI.IGNORED_ERRORS)
+class TestBlockchairAPI:
+    def test_get_balance_return_type(self):
+        assert isinstance(BlockchairAPI.get_balance(MAIN_ADDRESS_USED1), int)
+
+    def test_get_balance_main_used(self):
+        assert BlockchairAPI.get_balance(MAIN_ADDRESS_USED3) > 0
+
+    def test_get_balance_main_unused(self):
+        assert BlockchairAPI.get_balance(MAIN_ADDRESS_UNUSED) == 0
+
+    def test_get_balance_test_used(self):
+        assert BlockchairAPI.get_balance_testnet(TEST_ADDRESS_USED2) > 0
+
+    def test_get_balance_test_unused(self):
+        assert BlockchairAPI.get_balance_testnet(TEST_ADDRESS_UNUSED) == 0
+
+    def test_get_transactions_return_type(self):
+        assert iter(BlockchairAPI.get_transactions(MAIN_ADDRESS_USED1))
+
+    def test_get_transactions_main_used(self):
+        assert len(BlockchairAPI.get_transactions(MAIN_ADDRESS_USED1)) >= 236
+
+    def test_get_transactions_main_unused(self):
+        assert len(BlockchairAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
+
+    def test_get_transactions_test_used(self):
+        assert len(BlockchairAPI.get_transactions_testnet(TEST_ADDRESS_USED2)) >= 444
+
+    def test_get_transactions_test_unused(self):
+        assert len(BlockchairAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
+
+    def test_get_transaction_by_id_valid(self):
+        tx = BlockchairAPI.get_transaction_by_id(MAIN_TX_VALID)
+        assert calc_txid(tx) == MAIN_TX_VALID
+
+    def test_get_transaction_by_id_invalid(self):
+        assert BlockchairAPI.get_transaction_by_id(TX_INVALID) == None
+
+    def test_get_transaction_by_id_test_valid(self):
+        tx = BlockchairAPI.get_transaction_by_id_testnet(TEST_TX_VALID)
+        assert calc_txid(tx) == TEST_TX_VALID
+
+    def test_get_transaction_by_id_test_invalid(self):
+        assert BlockchairAPI.get_transaction_by_id_testnet(TX_INVALID) == None
+
+    def test_get_unspent_return_type(self):
+        assert iter(BlockchairAPI.get_unspent(MAIN_ADDRESS_USED1))
+
+    def test_get_unspent_main_used(self):
+        assert len(BlockchairAPI.get_unspent(MAIN_ADDRESS_USED3)) >= 2783
+
+    def test_get_unspent_main_unused(self):
+        assert len(BlockchairAPI.get_unspent(MAIN_ADDRESS_UNUSED)) == 0
+
+    def test_get_unspent_test_used(self):
+        assert len(BlockchairAPI.get_unspent_testnet(TEST_ADDRESS_USED2)) >= 196
+
+    def test_get_unspent_test_unused(self):
+        assert len(BlockchairAPI.get_unspent_testnet(TEST_ADDRESS_UNUSED)) == 0
+
+
+@decorate_methods(catch_errors_raise_warnings, NetworkAPI.IGNORED_ERRORS)
+class TestBlockstreamAPI:
+    def test_get_balance_return_type(self):
+        assert isinstance(BlockstreamAPI.get_balance(MAIN_ADDRESS_USED1), int)
+
+    def test_get_balance_main_used(self):
+        assert BlockstreamAPI.get_balance(MAIN_ADDRESS_USED3) > 0
+
+    def test_get_balance_main_unused(self):
+        assert BlockstreamAPI.get_balance(MAIN_ADDRESS_UNUSED) == 0
+
+    def test_get_balance_test_used(self):
+        assert BlockstreamAPI.get_balance_testnet(TEST_ADDRESS_USED2) > 0
+
+    def test_get_balance_test_unused(self):
+        assert BlockstreamAPI.get_balance_testnet(TEST_ADDRESS_UNUSED) == 0
+
+    def test_get_transactions_return_type(self):
+        assert iter(BlockstreamAPI.get_transactions(MAIN_ADDRESS_USED1))
+
+    def test_get_transactions_main_used(self):
+        assert len(BlockstreamAPI.get_transactions(MAIN_ADDRESS_USED1)) >= 236
+
+    def test_get_transactions_main_unused(self):
+        assert len(BlockstreamAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
+
+    def test_get_transactions_test_used(self):
+        assert len(BlockstreamAPI.get_transactions_testnet(TEST_ADDRESS_USED2)) >= 444
+
+    def test_get_transactions_test_unused(self):
+        assert len(BlockstreamAPI.get_transactions_testnet(TEST_ADDRESS_UNUSED)) == 0
+
+    def test_get_transaction_by_id_valid(self):
+        tx = BlockstreamAPI.get_transaction_by_id(MAIN_TX_VALID)
+        assert calc_txid(tx) == MAIN_TX_VALID
+
+    def test_get_transaction_by_id_invalid(self):
+        assert BlockstreamAPI.get_transaction_by_id(TX_INVALID) == None
+
+    def test_get_transaction_by_id_test_valid(self):
+        tx = BlockstreamAPI.get_transaction_by_id_testnet(TEST_TX_VALID)
+        assert calc_txid(tx) == TEST_TX_VALID
+
+    def test_get_transaction_by_id_test_invalid(self):
+        assert BlockstreamAPI.get_transaction_by_id_testnet(TX_INVALID) == None
+
+    def test_get_unspent_return_type(self):
+        assert iter(BlockstreamAPI.get_unspent(MAIN_ADDRESS_USED1))
+
+    def test_get_unspent_main_used(self):
+        assert len(BlockstreamAPI.get_unspent(MAIN_ADDRESS_USED3)) >= 2783
+
+    def test_get_unspent_main_unused(self):
+        assert len(BlockstreamAPI.get_unspent(MAIN_ADDRESS_UNUSED)) == 0
+
+    def test_get_unspent_test_used(self):
+        assert len(BlockstreamAPI.get_unspent_testnet(TEST_ADDRESS_USED2)) >= 196
+
+    def test_get_unspent_test_unused(self):
+        assert len(BlockstreamAPI.get_unspent_testnet(TEST_ADDRESS_UNUSED)) == 0
 
 
 @decorate_methods(catch_errors_raise_warnings, NetworkAPI.IGNORED_ERRORS)
@@ -463,7 +615,7 @@ class TestSmartbitAPI:
         assert isinstance(SmartbitAPI.get_balance(MAIN_ADDRESS_USED1), int)
 
     def test_get_balance_main_used(self):
-        assert SmartbitAPI.get_balance(MAIN_ADDRESS_USED1) > 0
+        assert SmartbitAPI.get_balance(MAIN_ADDRESS_USED3) > 0
 
     def test_get_balance_main_unused(self):
         assert SmartbitAPI.get_balance(MAIN_ADDRESS_UNUSED) == 0
@@ -478,7 +630,7 @@ class TestSmartbitAPI:
         assert iter(SmartbitAPI.get_transactions(MAIN_ADDRESS_USED1))
 
     def test_get_transactions_main_used(self):
-        assert len(SmartbitAPI.get_transactions(MAIN_ADDRESS_USED1)) >= 218
+        assert len(SmartbitAPI.get_transactions(MAIN_ADDRESS_USED1)) >= 236
 
     def test_get_transactions_main_unused(self):
         assert len(SmartbitAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
@@ -507,13 +659,13 @@ class TestSmartbitAPI:
         assert iter(SmartbitAPI.get_unspent(MAIN_ADDRESS_USED1))
 
     def test_get_unspent_main_used(self):
-        assert len(SmartbitAPI.get_unspent(MAIN_ADDRESS_USED2)) >= 1
+        assert len(SmartbitAPI.get_unspent(MAIN_ADDRESS_USED3)) >= 2783
 
     def test_get_unspent_main_unused(self):
         assert len(SmartbitAPI.get_unspent(MAIN_ADDRESS_UNUSED)) == 0
 
     def test_get_unspent_test_used(self):
-        assert len(SmartbitAPI.get_unspent_testnet(TEST_ADDRESS_USED2)) >= 194
+        assert len(SmartbitAPI.get_unspent_testnet(TEST_ADDRESS_USED2)) >= 196
 
     def test_get_unspent_test_unused(self):
         assert len(SmartbitAPI.get_unspent_testnet(TEST_ADDRESS_UNUSED)) == 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,26 @@ def catch_errors_raise_warnings(f, ignored_errors):  # pragma: no cover
         try:
             f(*args, **kwargs)
         except ignored_errors:
-            warnings.warn('Unreachable API from '.format(f.__name__), Warning)
+            warnings.warn('Unreachable API from {}'.format(f.__name__), Warning)
             assert True
+
+    return wrapper
+
+
+def check_not_all_raise_errors(fs, ignored_errors):  # pragma: no cover
+    def wrapper(*args, **kwargs):
+        success = False
+        ret = []
+        for f in fs:
+            try:
+                ret.append(f(*args, **kwargs))
+                success = True
+            except ignored_errors:
+                continue
+
+        if not success:
+            raise ConnectionError('All API calls to {} are unreachable'.format(fs[0].__name__))
+
+        return ret
 
     return wrapper


### PR DESCRIPTION
*Due to time-out errors adding more network API's makes it even more difficult to pass all the tests. This problem still persists with this PR and may make it worse due to the three new APIs!*

## Fix for testing balance > 0
This PR fixes the testing error from `test_get_balance_main_used` inside `BitpayAPI`, `BlockchainAPI` and `SmartbitAPI`. 

The reason was that the address being checked was used up and has a balance of 0, while the tests are asserting that the balance must be greater than 0.

It has been fixed by referring to Counterparty's burn-of-proof address `1CounterpartyXXXXXXXXXXXXXXXUWLpVr` and should therefore always have a balance greater than 0.

## Adding network APIs

The PR further adds three new network APIs: 
* Btc.com, 
* Blockstream.info, and 
* Blockchair.com. 

Blockchair was the most straight-forward to implement as it includes a "context" with each response that is very useful in case the immediate response does not include information that we need (e.g. confirmations, scriptPubKey, etc.). However for the first two APIs there were minor issues that I want to mention and eventually discuss:

1. For the new `BTCcomAPI` and `BlockstreamAPI`: 
When unspents are returned the scriptPubKey of the address is *not* included with the response. We must therefore calculate it from the address using our helper function `address_to_scriptpubkey` found inside `bit.transaction`.
2. For the new BlockstreamAPI: 
When unspents are returned it will include the block number the transaction was confirmed in, but neither include the number of confirmations nor the current block height. We must therefore first poll the current block height to then be able to calculate the confirmations for each unspent transaction returned.
3. For the new `BlockstreamAPI`:
Returned unspents are not sorted by any metric and appear to be random. To compare them directly with unspents returned from other APIs the returned unspents are immediately sorted by their confirmation number.

## Future development

If this PR has been checked and should be approved, then the next step will be to add a features-supported functionality, allowing `NetworkAPI` to poll the APIs with required features supported depending on the use-case, e.g. for bech32 addresses.