### PR TITLE
Add support for passing raw hexadecimal messages to `send`

### DIFF
--- a/bit/transaction.py
+++ b/bit/transaction.py
@@ -416,7 +416,7 @@ def deserialize(tx):
 
 def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True,
                      message=None, compressed=True, absolute_fee=False,
-                     min_change=0, version='main', is_raw=False):
+                     min_change=0, version='main', message_is_hex=False):
     """
     sanitize_tx_data()
 
@@ -436,7 +436,7 @@ def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True,
     messages = []
 
     if message:
-        if is_raw:
+        if message_is_hex:
             message_chunks = chunk_data(message, MESSAGE_LIMIT)
         else:
             message_chunks = chunk_data(message.encode('utf-8'), MESSAGE_LIMIT)

--- a/bit/transaction.py
+++ b/bit/transaction.py
@@ -416,7 +416,7 @@ def deserialize(tx):
 
 def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True,
                      message=None, compressed=True, absolute_fee=False,
-                     min_change=0, version='main'):
+                     min_change=0, version='main', is_raw=False):
     """
     sanitize_tx_data()
 
@@ -436,7 +436,10 @@ def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True,
     messages = []
 
     if message:
-        message_chunks = chunk_data(message.encode('utf-8'), MESSAGE_LIMIT)
+        if is_raw:
+            message_chunks = chunk_data(message, MESSAGE_LIMIT)
+        else:
+            message_chunks = chunk_data(message.encode('utf-8'), MESSAGE_LIMIT)
 
         for message in message_chunks:
             messages.append((message, 0))

--- a/bit/wallet.py
+++ b/bit/wallet.py
@@ -255,7 +255,7 @@ class PrivateKey(BaseKey):
 
     def create_transaction(self, outputs, fee=None, absolute_fee=False,
                            leftover=None, combine=True, message=None,
-                           unspents=None, is_raw=False):  # pragma: no cover
+                           unspents=None, message_is_hex=False):  # pragma: no cover
         """Creates a signed P2PKH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -306,13 +306,13 @@ class PrivateKey(BaseKey):
             message=message,
             absolute_fee=absolute_fee,
             version=self.version,
-            is_raw=is_raw
+            message_is_hex=message_is_hex
         )
 
         return create_new_transaction(self, unspents, outputs)
 
     def send(self, outputs, fee=None, absolute_fee=False, leftover=None,
-             combine=True, message=None, unspents=None, is_raw=False):  # pragma: no cover
+             combine=True, message=None, unspents=None, message_is_hex=False):  # pragma: no cover
         """Creates a signed P2PKH transaction and attempts to broadcast it on
         the blockchain. This accepts the same arguments as
         :func:`~bit.PrivateKey.create_transaction`.
@@ -355,7 +355,7 @@ class PrivateKey(BaseKey):
             combine=combine,
             message=message,
             unspents=unspents,
-            is_raw=is_raw
+            message_is_hex=message_is_hex
         )
 
         NetworkAPI.broadcast_tx(tx_hex)
@@ -365,7 +365,7 @@ class PrivateKey(BaseKey):
     @classmethod
     def prepare_transaction(cls, address, outputs, compressed=True, fee=None,
                             absolute_fee=False, leftover=None, combine=True,
-                            message=None, unspents=None, is_raw=False):  # pragma: no cover
+                            message=None, unspents=None, message_is_hex=False):  # pragma: no cover
         """Prepares a P2PKH transaction for offline signing.
 
         :param address: The address the funds will be sent from.
@@ -411,7 +411,7 @@ class PrivateKey(BaseKey):
             message=message,
             absolute_fee=absolute_fee,
             version='main',
-            is_raw=is_raw
+            message_is_hex=message_is_hex
         )
 
         data = {
@@ -624,7 +624,7 @@ class PrivateKeyTestnet(BaseKey):
 
     def create_transaction(self, outputs, fee=None, absolute_fee=False,
                            leftover=None, combine=True, message=None,
-                           unspents=None, is_raw=False):  # pragma: no cover
+                           unspents=None, message_is_hex=False):  # pragma: no cover
         """Creates a signed P2PKH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -675,13 +675,13 @@ class PrivateKeyTestnet(BaseKey):
             message=message,
             absolute_fee=absolute_fee,
             version=self.version,
-            is_raw=is_raw
+            message_is_hex=message_is_hex
         )
 
         return create_new_transaction(self, unspents, outputs)
 
     def send(self, outputs, fee=None, absolute_fee=False, leftover=None,
-             combine=True, message=None, unspents=None, is_raw=False):  # pragma: no cover
+             combine=True, message=None, unspents=None, message_is_hex=False):  # pragma: no cover
         """Creates a signed P2PKH transaction and attempts to broadcast it on
         the testnet blockchain. This accepts the same arguments as
         :func:`~bit.PrivateKeyTestnet.create_transaction`.
@@ -724,7 +724,7 @@ class PrivateKeyTestnet(BaseKey):
             combine=combine,
             message=message,
             unspents=unspents,
-            is_raw=is_raw
+            message_is_hex=message_is_hex
         )
 
         NetworkAPI.broadcast_tx_testnet(tx_hex)
@@ -734,7 +734,7 @@ class PrivateKeyTestnet(BaseKey):
     @classmethod
     def prepare_transaction(cls, address, outputs, compressed=True, fee=None,
                             absolute_fee=False, leftover=None, combine=True,
-                            message=None, unspents=None, is_raw=False):  # pragma: no cover
+                            message=None, unspents=None, message_is_hex=False):  # pragma: no cover
         """Prepares a P2PKH transaction for offline signing.
 
         :param address: The address the funds will be sent from.
@@ -780,7 +780,7 @@ class PrivateKeyTestnet(BaseKey):
             message=message,
             absolute_fee=absolute_fee,
             version='test',
-            is_raw=is_raw
+            message_is_hex=message_is_hex
         )
 
         data = {
@@ -1029,7 +1029,7 @@ class MultiSig:
 
     def create_transaction(self, outputs, fee=None, absolute_fee=False,
                            leftover=None, combine=True, message=None,
-                           unspents=None, is_raw=False):  # pragma: no cover
+                           unspents=None, message_is_hex=False):  # pragma: no cover
         """Creates a signed P2SH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -1080,7 +1080,7 @@ class MultiSig:
             message=message,
             absolute_fee=absolute_fee,
             version=self.version,
-            is_raw=is_raw
+            message_is_hex=message_is_hex
         )
 
         return create_new_transaction(self, unspents, outputs)
@@ -1088,7 +1088,7 @@ class MultiSig:
     @classmethod
     def prepare_transaction(cls, address, outputs, compressed=True, fee=None,
                             absolute_fee=False, leftover=None, combine=True,
-                            message=None, unspents=None, is_raw=False):  # pragma: no cover
+                            message=None, unspents=None, message_is_hex=False):  # pragma: no cover
         """Prepares a P2SH transaction for offline signing.
 
         :param address: The address the funds will be sent from.
@@ -1134,7 +1134,7 @@ class MultiSig:
             message=message,
             absolute_fee=absolute_fee,
             version='main',
-            is_raw=is_raw
+            message_is_hex=message_is_hex
         )
 
         data = {
@@ -1334,7 +1334,7 @@ class MultiSigTestnet:
 
     def create_transaction(self, outputs, fee=None, absolute_fee=False,
                            leftover=None, combine=True, message=None,
-                           unspents=None, is_raw=False):  # pragma: no cover
+                           unspents=None, message_is_hex=False):  # pragma: no cover
         """Creates a signed P2SH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -1385,7 +1385,7 @@ class MultiSigTestnet:
             message=message,
             absolute_fee=absolute_fee,
             version=self.version,
-            is_raw=is_raw
+            message_is_hex=message_is_hex
         )
 
         return create_new_transaction(self, unspents, outputs)
@@ -1393,7 +1393,7 @@ class MultiSigTestnet:
     @classmethod
     def prepare_transaction(cls, address, outputs, compressed=True, fee=None,
                             absolute_fee=False, leftover=None, combine=True,
-                            message=None, unspents=None, is_raw=False):  # pragma: no cover
+                            message=None, unspents=None, message_is_hex=False):  # pragma: no cover
         """Prepares a P2SH transaction for offline signing.
 
         :param address: The address the funds will be sent from.
@@ -1439,7 +1439,7 @@ class MultiSigTestnet:
             message=message,
             absolute_fee=absolute_fee,
             version='test',
-            is_raw=is_raw
+            message_is_hex=message_is_hex
         )
 
         data = {

--- a/bit/wallet.py
+++ b/bit/wallet.py
@@ -255,7 +255,7 @@ class PrivateKey(BaseKey):
 
     def create_transaction(self, outputs, fee=None, absolute_fee=False,
                            leftover=None, combine=True, message=None,
-                           unspents=None):  # pragma: no cover
+                           unspents=None, is_raw=False):  # pragma: no cover
         """Creates a signed P2PKH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -305,13 +305,14 @@ class PrivateKey(BaseKey):
             combine=combine,
             message=message,
             absolute_fee=absolute_fee,
-            version=self.version
+            version=self.version,
+            is_raw=is_raw
         )
 
         return create_new_transaction(self, unspents, outputs)
 
     def send(self, outputs, fee=None, absolute_fee=False, leftover=None,
-             combine=True, message=None, unspents=None):  # pragma: no cover
+             combine=True, message=None, unspents=None, is_raw=False):  # pragma: no cover
         """Creates a signed P2PKH transaction and attempts to broadcast it on
         the blockchain. This accepts the same arguments as
         :func:`~bit.PrivateKey.create_transaction`.
@@ -353,7 +354,8 @@ class PrivateKey(BaseKey):
             leftover=leftover,
             combine=combine,
             message=message,
-            unspents=unspents
+            unspents=unspents,
+            is_raw=is_raw
         )
 
         NetworkAPI.broadcast_tx(tx_hex)
@@ -363,7 +365,7 @@ class PrivateKey(BaseKey):
     @classmethod
     def prepare_transaction(cls, address, outputs, compressed=True, fee=None,
                             absolute_fee=False, leftover=None, combine=True,
-                            message=None, unspents=None):  # pragma: no cover
+                            message=None, unspents=None, is_raw=False):  # pragma: no cover
         """Prepares a P2PKH transaction for offline signing.
 
         :param address: The address the funds will be sent from.
@@ -408,7 +410,8 @@ class PrivateKey(BaseKey):
             combine=combine,
             message=message,
             absolute_fee=absolute_fee,
-            version='main'
+            version='main',
+            is_raw=is_raw
         )
 
         data = {
@@ -621,7 +624,7 @@ class PrivateKeyTestnet(BaseKey):
 
     def create_transaction(self, outputs, fee=None, absolute_fee=False,
                            leftover=None, combine=True, message=None,
-                           unspents=None):  # pragma: no cover
+                           unspents=None, is_raw=False):  # pragma: no cover
         """Creates a signed P2PKH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -671,13 +674,14 @@ class PrivateKeyTestnet(BaseKey):
             combine=combine,
             message=message,
             absolute_fee=absolute_fee,
-            version=self.version
+            version=self.version,
+            is_raw=is_raw
         )
 
         return create_new_transaction(self, unspents, outputs)
 
     def send(self, outputs, fee=None, absolute_fee=False, leftover=None,
-             combine=True, message=None, unspents=None):  # pragma: no cover
+             combine=True, message=None, unspents=None, is_raw=False):  # pragma: no cover
         """Creates a signed P2PKH transaction and attempts to broadcast it on
         the testnet blockchain. This accepts the same arguments as
         :func:`~bit.PrivateKeyTestnet.create_transaction`.
@@ -719,7 +723,8 @@ class PrivateKeyTestnet(BaseKey):
             leftover=leftover,
             combine=combine,
             message=message,
-            unspents=unspents
+            unspents=unspents,
+            is_raw=is_raw
         )
 
         NetworkAPI.broadcast_tx_testnet(tx_hex)
@@ -729,7 +734,7 @@ class PrivateKeyTestnet(BaseKey):
     @classmethod
     def prepare_transaction(cls, address, outputs, compressed=True, fee=None,
                             absolute_fee=False, leftover=None, combine=True,
-                            message=None, unspents=None):  # pragma: no cover
+                            message=None, unspents=None, is_raw=False):  # pragma: no cover
         """Prepares a P2PKH transaction for offline signing.
 
         :param address: The address the funds will be sent from.
@@ -774,7 +779,8 @@ class PrivateKeyTestnet(BaseKey):
             combine=combine,
             message=message,
             absolute_fee=absolute_fee,
-            version='test'
+            version='test',
+            is_raw=is_raw
         )
 
         data = {
@@ -1023,7 +1029,7 @@ class MultiSig:
 
     def create_transaction(self, outputs, fee=None, absolute_fee=False,
                            leftover=None, combine=True, message=None,
-                           unspents=None):  # pragma: no cover
+                           unspents=None, is_raw=False):  # pragma: no cover
         """Creates a signed P2SH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -1073,7 +1079,8 @@ class MultiSig:
             combine=combine,
             message=message,
             absolute_fee=absolute_fee,
-            version=self.version
+            version=self.version,
+            is_raw=is_raw
         )
 
         return create_new_transaction(self, unspents, outputs)
@@ -1081,7 +1088,7 @@ class MultiSig:
     @classmethod
     def prepare_transaction(cls, address, outputs, compressed=True, fee=None,
                             absolute_fee=False, leftover=None, combine=True,
-                            message=None, unspents=None):  # pragma: no cover
+                            message=None, unspents=None, is_raw=False):  # pragma: no cover
         """Prepares a P2SH transaction for offline signing.
 
         :param address: The address the funds will be sent from.
@@ -1126,7 +1133,8 @@ class MultiSig:
             combine=combine,
             message=message,
             absolute_fee=absolute_fee,
-            version='main'
+            version='main',
+            is_raw=is_raw
         )
 
         data = {
@@ -1326,7 +1334,7 @@ class MultiSigTestnet:
 
     def create_transaction(self, outputs, fee=None, absolute_fee=False,
                            leftover=None, combine=True, message=None,
-                           unspents=None):  # pragma: no cover
+                           unspents=None, is_raw=False):  # pragma: no cover
         """Creates a signed P2SH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -1376,7 +1384,8 @@ class MultiSigTestnet:
             combine=combine,
             message=message,
             absolute_fee=absolute_fee,
-            version=self.version
+            version=self.version,
+            is_raw=is_raw
         )
 
         return create_new_transaction(self, unspents, outputs)
@@ -1384,7 +1393,7 @@ class MultiSigTestnet:
     @classmethod
     def prepare_transaction(cls, address, outputs, compressed=True, fee=None,
                             absolute_fee=False, leftover=None, combine=True,
-                            message=None, unspents=None):  # pragma: no cover
+                            message=None, unspents=None, is_raw=False):  # pragma: no cover
         """Prepares a P2SH transaction for offline signing.
 
         :param address: The address the funds will be sent from.
@@ -1429,7 +1438,8 @@ class MultiSigTestnet:
             combine=combine,
             message=message,
             absolute_fee=absolute_fee,
-            version='test'
+            version='test',
+            is_raw=is_raw
         )
 
         data = {


### PR DESCRIPTION
## What is this?

This PR adds a new parameter `is_raw` onto the method `send` and all calling methods

## Why?

When you send a message in a transaction, `send` converts the message text into hexadecimal. If you have a message that is already hexadecimal, then it gets unnecessarily converted causing the message to double in length.

## Why should this be merged?

Being able to pass a message in as hexadecimal reduces overhead and requires less effort on both sides.
