### PR TITLE
Critical Bug: branch_and_bound is incompatible with absolute fees

### DIFF
--- a/bit/transaction.py
+++ b/bit/transaction.py
@@ -297,7 +297,7 @@ def select_coins(target, fee, output_size, min_change, *, absolute_fee=False, co
     sorted_unspents = sorted(unspents, key=lambda u: u.amount, reverse=True)
     selected_coins = []
 
-    if not consolidate:
+    if not consolidate and not absolute_fee:
         # Trying to find a perfect match using Branch-and-Bound:
         selected_coins = branch_and_bound(
             d=0, selected_coins=[], effective_value=0, target=target, fee=fee, sorted_unspents=sorted_unspents

--- a/bit/wallet.py
+++ b/bit/wallet.py
@@ -282,7 +282,8 @@ class PrivateKey(BaseKey):
         :type leftover: ``str``
         :param combine: Whether or not Bit should use all available UTXOs to
                         make future transactions smaller and therefore reduce
-                        fees. By default Bit will consolidate UTXOs.
+                        fees. By default Bit will consolidate UTXOs. Note: When
+                        setting :param absolute_fee: this is ignored.
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,

--- a/bit/wallet.py
+++ b/bit/wallet.py
@@ -349,7 +349,8 @@ class PrivateKey(BaseKey):
         :type leftover: ``str``
         :param combine: Whether or not Bit should use all available UTXOs to
                         make future transactions smaller and therefore reduce
-                        fees. By default Bit will consolidate UTXOs.
+                        fees. By default Bit will consolidate UTXOs. Note: When
+                        setting :param absolute_fee: this is ignored.
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,
@@ -415,7 +416,8 @@ class PrivateKey(BaseKey):
         :type leftover: ``str``
         :param combine: Whether or not Bit should use all available UTXOs to
                         make future transactions smaller and therefore reduce
-                        fees. By default Bit will consolidate UTXOs.
+                        fees. By default Bit will consolidate UTXOs. Note: When
+                        setting :param absolute_fee: this is ignored.
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,
@@ -667,7 +669,8 @@ class PrivateKeyTestnet(BaseKey):
         :type leftover: ``str``
         :param combine: Whether or not Bit should use all available UTXOs to
                         make future transactions smaller and therefore reduce
-                        fees. By default Bit will consolidate UTXOs.
+                        fees. By default Bit will consolidate UTXOs. Note: When
+                        setting :param absolute_fee: this is ignored.
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,
@@ -733,7 +736,8 @@ class PrivateKeyTestnet(BaseKey):
         :type leftover: ``str``
         :param combine: Whether or not Bit should use all available UTXOs to
                         make future transactions smaller and therefore reduce
-                        fees. By default Bit will consolidate UTXOs.
+                        fees. By default Bit will consolidate UTXOs. Note: When
+                        setting :param absolute_fee: this is ignored.
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,
@@ -799,7 +803,8 @@ class PrivateKeyTestnet(BaseKey):
         :type leftover: ``str``
         :param combine: Whether or not Bit should use all available UTXOs to
                         make future transactions smaller and therefore reduce
-                        fees. By default Bit will consolidate UTXOs.
+                        fees. By default Bit will consolidate UTXOs. Note: When
+                        setting :param absolute_fee: this is ignored.
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,
@@ -1091,7 +1096,8 @@ class MultiSig:
         :type leftover: ``str``
         :param combine: Whether or not Bit should use all available UTXOs to
                         make future transactions smaller and therefore reduce
-                        fees. By default Bit will consolidate UTXOs.
+                        fees. By default Bit will consolidate UTXOs. Note: When
+                        setting :param absolute_fee: this is ignored.
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,
@@ -1163,7 +1169,8 @@ class MultiSig:
         :type leftover: ``str``
         :param combine: Whether or not Bit should use all available UTXOs to
                         make future transactions smaller and therefore reduce
-                        fees. By default Bit will consolidate UTXOs.
+                        fees. By default Bit will consolidate UTXOs. Note: When
+                        setting :param absolute_fee: this is ignored.
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,
@@ -1410,7 +1417,8 @@ class MultiSigTestnet:
         :type leftover: ``str``
         :param combine: Whether or not Bit should use all available UTXOs to
                         make future transactions smaller and therefore reduce
-                        fees. By default Bit will consolidate UTXOs.
+                        fees. By default Bit will consolidate UTXOs. Note: When
+                        setting :param absolute_fee: this is ignored.
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,
@@ -1482,7 +1490,8 @@ class MultiSigTestnet:
         :type leftover: ``str``
         :param combine: Whether or not Bit should use all available UTXOs to
                         make future transactions smaller and therefore reduce
-                        fees. By default Bit will consolidate UTXOs.
+                        fees. By default Bit will consolidate UTXOs. Note: When
+                        setting :param absolute_fee: this is ignored.
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -629,7 +629,7 @@ class TestSanitizeTxData:
         # to this formula with one input
         # amount + overhead*fee <= unspent - unspent.vsize*fee < amount + overhead*fee + input*fee + output*fee
         # amount + 40*fee <= unspent - 148*fee < amount + 40*fee + 182*fee
-        # amount < unspent - 188*f < amount + 182*f
+        # amount <= unspent - 188*fee < amount + 182*fee
 
         fee = 8000
         unspents_original = [Unspent(2000000, 0, '', '', 0)]
@@ -947,14 +947,14 @@ class TestEstimateTxFee:
 class TestSelectCoins:
     def test_perfect_match(self):
         unspents, remaining = select_coins(
-            100000000, 0, [34, 34], 0, absolute_fee=True, consolidate=False, unspents=UNSPENTS_SEGWIT
+            100000000, 0, [34, 34], 0, absolute_fee=False, consolidate=False, unspents=UNSPENTS_SEGWIT
         )
         assert len(unspents) == 1
         assert remaining == 0
 
     def test_perfect_match_with_range(self):
         unspents, remaining = select_coins(
-            99960000, 200, [34, 34], 0, absolute_fee=True, consolidate=False, unspents=UNSPENTS_SEGWIT
+            99960000, 200, [34, 34], 0, absolute_fee=False, consolidate=False, unspents=UNSPENTS_SEGWIT
         )
         assert len(unspents) == 1
         assert remaining == 0
@@ -962,7 +962,7 @@ class TestSelectCoins:
     def test_random_draw(self):
         print(UNSPENTS_SEGWIT)
         unspents, remaining = select_coins(
-            150000000, 0, [34, 34], 0, absolute_fee=True, consolidate=False, unspents=UNSPENTS_SEGWIT
+            150000000, 0, [34, 34], 0, absolute_fee=False, consolidate=False, unspents=UNSPENTS_SEGWIT
         )
         assert all([u in UNSPENTS_SEGWIT for u in unspents])
         assert remaining == 50000000


### PR DESCRIPTION
**Unexpected behavior can occur when calling `create_transaction` with `combine=False` and `absolute_fees=True`.**

The method `select_coins` tries to find a perfect match for the transaction amount in the [first step](https://github.com/ofek/bit/blob/master/bit/transaction.py#L300). Here it passes the fee to `branch_and_bound` without further checks. However, `branch_and_bound` tries to calculate a `target_to_match` based on the passed fee implicitly assuming the unit is sats/byte. This yields to wrong target calculations and can accidentally match a much larger input. 
If this false match occurs, bad things happen after returning from `branch_and_bound` in [line 305](https://github.com/ofek/bit/blob/master/bit/transaction.py#L305), where `remaining` is set to zero. 

This has the result that no additional output for the leftover is attached in [sanitize_tx_data](https://github.com/ofek/bit/blob/master/bit/transaction.py#L437). Practically, this means paying `inputs - outputs` as very high fees. 

In my experience, this meant accidentally paying over $700 as fees for a $1 transaction (at least made some miner happy). 
Hope this bug report helps someone to not waste a lot of bitcoin. 

My commit is just some quick hotfix, I'm not sure how to make `branch_and_bound` work with absolute fees.

BTW: If someone feels bad for me, feel free to donate :) bc1q9zy0qlh70awpdrgk996t4rhl457p87kadp3azy
