### PR TITLE
Fix Unspent.confirmations from Blockchair API

### DIFF
--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -242,7 +242,7 @@ class BlockchairAPI:
             unspents.extend(
                 Unspent(
                     utxo['value'],
-                    block_height - utxo['block_id'],
+                    block_height - utxo['block_id'] + 1 if utxo['block_id'] != -1 else 0,
                     script_pubkey,
                     utxo['transaction_hash'],
                     utxo['index'],


### PR DESCRIPTION
New formula takes into account that response['utxo'][0]['block_id'] will be set to -1 if the transaction is pending and the block height if mined.

Fixes #119