### PR TITLE
Add support for replace-by-fee (BIP 125) - alternative.

### DIFF
--- a/bit/network/meta.py
+++ b/bit/network/meta.py
@@ -1,3 +1,5 @@
+from bit.constants import SEQUENCE
+
 TX_TRUST_LOW = 1
 TX_TRUST_MEDIUM = 6
 TX_TRUST_HIGH = 30
@@ -23,9 +25,9 @@ UNSPENT_TYPES = {
 class Unspent:
     """Represents an unspent transaction output (UTXO)."""
 
-    __slots__ = ('amount', 'confirmations', 'script', 'txid', 'txindex', 'type', 'vsize', 'segwit')
+    __slots__ = ('amount', 'confirmations', 'script', 'txid', 'txindex', 'type', 'vsize', 'segwit', 'sequence')
 
-    def __init__(self, amount, confirmations, script, txid, txindex, type='p2pkh', vsize=None, segwit=None):
+    def __init__(self, amount, confirmations, script, txid, txindex, type='p2pkh', vsize=None, segwit=None, sequence=SEQUENCE):
         self.amount = amount
         self.confirmations = confirmations
         self.script = script
@@ -34,6 +36,7 @@ class Unspent:
         self.type = type if type in UNSPENT_TYPES else 'unknown'
         self.vsize = vsize if vsize else UNSPENT_TYPES[self.type]['vsize']
         self.segwit = UNSPENT_TYPES[self.type]['segwit']
+        self.sequence = sequence
 
     def to_dict(self):
         return {attr: getattr(self, attr) for attr in Unspent.__slots__}
@@ -49,6 +52,7 @@ class Unspent:
             and self.txid == other.txid
             and self.txindex == other.txindex
             and self.segwit == other.segwit
+            and self.sequence == other.sequence
         )
 
     def __repr__(self):
@@ -59,6 +63,7 @@ class Unspent:
             repr(self.txid),
             repr(self.txindex),
             repr(self.segwit),
+            repr(self.sequence)
         )
 
     def set_type(self, type, vsize=0):

--- a/bit/transaction.py
+++ b/bit/transaction.py
@@ -722,7 +722,7 @@ def create_new_transaction(private_key, unspents, outputs):
         txid = hex_to_bytes(unspent.txid)[::-1]
         txindex = unspent.txindex.to_bytes(4, byteorder='little')
         amount = int(unspent.amount).to_bytes(8, byteorder='little')
-        inputs.append(TxIn(script_sig, txid, txindex, amount=amount, segwit_input=unspent.segwit))
+        inputs.append(TxIn(script_sig, txid, txindex, amount=amount, segwit_input=unspent.segwit, sequence=unspent.sequence))
 
     tx_unsigned = TxObj(version, inputs, outputs, lock_time)
 


### PR DESCRIPTION
A simpler alternative proposal to #122 (although they could be combined).

Unspent class has an attribute for the sequence number that is read when creating a transaction. A user can set the sequence number of his Unspents to 0xfffffffd to make his transactions replaceable.

Fixes #121