### PR TITLE
Add tests and support for replace-by-fee (BIP 125).

### DIFF
--- a/bit/network/meta.py
+++ b/bit/network/meta.py
@@ -1,3 +1,5 @@
+from bit.constants import SEQUENCE
+
 TX_TRUST_LOW = 1
 TX_TRUST_MEDIUM = 6
 TX_TRUST_HIGH = 30
@@ -23,9 +25,9 @@ UNSPENT_TYPES = {
 class Unspent:
     """Represents an unspent transaction output (UTXO)."""
 
-    __slots__ = ('amount', 'confirmations', 'script', 'txid', 'txindex', 'type', 'vsize', 'segwit')
+    __slots__ = ('amount', 'confirmations', 'script', 'txid', 'txindex', 'type', 'vsize', 'segwit', 'sequence')
 
-    def __init__(self, amount, confirmations, script, txid, txindex, type='p2pkh', vsize=None, segwit=None):
+    def __init__(self, amount, confirmations, script, txid, txindex, type='p2pkh', vsize=None, segwit=None, sequence=SEQUENCE):
         self.amount = amount
         self.confirmations = confirmations
         self.script = script
@@ -34,6 +36,7 @@ class Unspent:
         self.type = type if type in UNSPENT_TYPES else 'unknown'
         self.vsize = vsize if vsize else UNSPENT_TYPES[self.type]['vsize']
         self.segwit = UNSPENT_TYPES[self.type]['segwit']
+        self.sequence = sequence
 
     def to_dict(self):
         return {attr: getattr(self, attr) for attr in Unspent.__slots__}
@@ -49,16 +52,18 @@ class Unspent:
             and self.txid == other.txid
             and self.txindex == other.txindex
             and self.segwit == other.segwit
+            and self.sequence == other.sequence
         )
 
     def __repr__(self):
-        return 'Unspent(amount={}, confirmations={}, script={}, txid={}, txindex={}, segwit={})'.format(
+        return 'Unspent(amount={}, confirmations={}, script={}, txid={}, txindex={}, segwit={}, sequence={})'.format(
             repr(self.amount),
             repr(self.confirmations),
             repr(self.script),
             repr(self.txid),
             repr(self.txindex),
             repr(self.segwit),
+            repr(int.from_bytes(self.sequence, byteorder='little'))
         )
 
     def set_type(self, type, vsize=0):
@@ -66,3 +71,7 @@ class Unspent:
         self.vsize = vsize if vsize else UNSPENT_TYPES[self.type]['vsize']
         self.segwit = UNSPENT_TYPES[self.type]['segwit']
         return self
+
+    def opt_in_for_RBF(self):
+        if int.from_bytes(self.sequence, byteorder='little') > 0xFFFFFFFD:
+            self.sequence = 0xFFFFFFFD.to_bytes(4, byteorder='little')

--- a/bit/network/meta.py
+++ b/bit/network/meta.py
@@ -27,7 +27,8 @@ class Unspent:
 
     __slots__ = ('amount', 'confirmations', 'script', 'txid', 'txindex', 'type', 'vsize', 'segwit', 'sequence')
 
-    def __init__(self, amount, confirmations, script, txid, txindex, type='p2pkh', vsize=None, segwit=None, sequence=SEQUENCE):
+    def __init__(self, amount, confirmations, script, txid, txindex, type='p2pkh', vsize=None, segwit=None,
+                 sequence=int.from_bytes(SEQUENCE, byteorder='little')):
         self.amount = amount
         self.confirmations = confirmations
         self.script = script
@@ -63,7 +64,7 @@ class Unspent:
             repr(self.txid),
             repr(self.txindex),
             repr(self.segwit),
-            repr(int.from_bytes(self.sequence, byteorder='little'))
+            repr(self.sequence)
         )
 
     def set_type(self, type, vsize=0):
@@ -73,5 +74,5 @@ class Unspent:
         return self
 
     def opt_in_for_RBF(self):
-        if int.from_bytes(self.sequence, byteorder='little') > 0xFFFFFFFD:
-            self.sequence = 0xFFFFFFFD.to_bytes(4, byteorder='little')
+        if self.sequence > 4294967293:
+            self.sequence = 4294967293

--- a/bit/transaction.py
+++ b/bit/transaction.py
@@ -727,8 +727,9 @@ def create_new_transaction(private_key, unspents, outputs):
         txid = hex_to_bytes(unspent.txid)[::-1]
         txindex = unspent.txindex.to_bytes(4, byteorder='little')
         amount = int(unspent.amount).to_bytes(8, byteorder='little')
+        sequence = unspent.sequence.to_bytes(4, byteorder='little')
         inputs.append(TxIn(script_sig, txid, txindex, amount=amount, segwit_input=unspent.segwit,
-                           sequence=unspent.sequence))
+                           sequence=sequence))
 
     tx_unsigned = TxObj(version, inputs, outputs, lock_time)
 

--- a/bit/transaction.py
+++ b/bit/transaction.py
@@ -387,6 +387,7 @@ def sanitize_tx_data(
     min_change=0,
     version='main',
     message_is_hex=False,
+    replace_by_fee=False
 ):
     """
     sanitize_tx_data()
@@ -432,6 +433,10 @@ def sanitize_tx_data(
         consolidate=combine,
         unspents=unspents,
     )
+
+    if replace_by_fee:
+        for unspent in unspents:
+            unspent.opt_in_for_RBF()
 
     if remaining > 0:
         outputs.append((leftover, remaining))
@@ -722,7 +727,8 @@ def create_new_transaction(private_key, unspents, outputs):
         txid = hex_to_bytes(unspent.txid)[::-1]
         txindex = unspent.txindex.to_bytes(4, byteorder='little')
         amount = int(unspent.amount).to_bytes(8, byteorder='little')
-        inputs.append(TxIn(script_sig, txid, txindex, amount=amount, segwit_input=unspent.segwit))
+        inputs.append(TxIn(script_sig, txid, txindex, amount=amount, segwit_input=unspent.segwit,
+                           sequence=unspent.sequence))
 
     tx_unsigned = TxObj(version, inputs, outputs, lock_time)
 

--- a/bit/wallet.py
+++ b/bit/wallet.py
@@ -435,7 +435,6 @@ class PrivateKey(BaseKey):
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
-        :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
         :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
         :type replace_by_fee: ``bool``
         :returns: JSON storing data required to create an offline transaction.
@@ -835,7 +834,6 @@ class PrivateKeyTestnet(BaseKey):
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
-        :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
         :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
         :type replace_by_fee: ``bool``
         :returns: JSON storing data required to create an offline transaction.
@@ -1210,7 +1208,6 @@ class MultiSig:
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
-        :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
         :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
         :type replace_by_fee: ``bool``
         :returns: JSON storing data required to create an offline transaction.
@@ -1539,7 +1536,6 @@ class MultiSigTestnet:
         :type message: ``str``
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the blockchain itself.
-        :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
         :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
         :type replace_by_fee: ``bool``

--- a/bit/wallet.py
+++ b/bit/wallet.py
@@ -262,6 +262,7 @@ class PrivateKey(BaseKey):
         message=None,
         unspents=None,
         message_is_hex=False,
+        replace_by_fee=False
     ):  # pragma: no cover
         """Creates a signed P2PKH transaction.
 
@@ -292,6 +293,8 @@ class PrivateKey(BaseKey):
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
+        :type replace_by_fee: ``bool``
         :returns: The signed transaction as hex.
         :rtype: ``str``
         """
@@ -313,6 +316,7 @@ class PrivateKey(BaseKey):
             absolute_fee=absolute_fee,
             version=self.version,
             message_is_hex=message_is_hex,
+            replace_by_fee=replace_by_fee
         )
 
         return create_new_transaction(self, unspents, outputs)
@@ -327,6 +331,7 @@ class PrivateKey(BaseKey):
         message=None,
         unspents=None,
         message_is_hex=False,
+        replace_by_fee=False
     ):  # pragma: no cover
         """Creates a signed P2PKH transaction and attempts to broadcast it on
         the blockchain. This accepts the same arguments as
@@ -359,6 +364,8 @@ class PrivateKey(BaseKey):
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
+        :type replace_by_fee: ``bool``
         :returns: The transaction ID.
         :rtype: ``str``
         """
@@ -372,6 +379,7 @@ class PrivateKey(BaseKey):
             message=message,
             unspents=unspents,
             message_is_hex=message_is_hex,
+            replace_by_fee=replace_by_fee
         )
 
         NetworkAPI.broadcast_tx(tx_hex)
@@ -391,6 +399,7 @@ class PrivateKey(BaseKey):
         message=None,
         unspents=None,
         message_is_hex=False,
+        replace_by_fee=False
     ):  # pragma: no cover
         """Prepares a P2PKH transaction for offline signing.
 
@@ -426,6 +435,9 @@ class PrivateKey(BaseKey):
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
+        :type replace_by_fee: ``bool``
         :returns: JSON storing data required to create an offline transaction.
         :rtype: ``str``
         """
@@ -439,6 +451,7 @@ class PrivateKey(BaseKey):
             absolute_fee=absolute_fee,
             version='main',
             message_is_hex=message_is_hex,
+            replace_by_fee=replace_by_fee
         )
 
         data = {'unspents': [unspent.to_dict() for unspent in unspents], 'outputs': outputs}
@@ -649,6 +662,7 @@ class PrivateKeyTestnet(BaseKey):
         message=None,
         unspents=None,
         message_is_hex=False,
+        replace_by_fee=False
     ):  # pragma: no cover
         """Creates a signed P2PKH transaction.
 
@@ -679,6 +693,8 @@ class PrivateKeyTestnet(BaseKey):
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the testnet blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
+        :type replace_by_fee: ``bool``
         :returns: The signed transaction as hex.
         :rtype: ``str``
         """
@@ -700,6 +716,7 @@ class PrivateKeyTestnet(BaseKey):
             absolute_fee=absolute_fee,
             version=self.version,
             message_is_hex=message_is_hex,
+            replace_by_fee=replace_by_fee
         )
 
         return create_new_transaction(self, unspents, outputs)
@@ -714,6 +731,7 @@ class PrivateKeyTestnet(BaseKey):
         message=None,
         unspents=None,
         message_is_hex=False,
+        replace_by_fee=False
     ):  # pragma: no cover
         """Creates a signed P2PKH transaction and attempts to broadcast it on
         the testnet blockchain. This accepts the same arguments as
@@ -746,6 +764,8 @@ class PrivateKeyTestnet(BaseKey):
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the testnet blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
+        :type replace_by_fee: ``bool``
         :returns: The transaction ID.
         :rtype: ``str``
         """
@@ -759,6 +779,7 @@ class PrivateKeyTestnet(BaseKey):
             message=message,
             unspents=unspents,
             message_is_hex=message_is_hex,
+            replace_by_fee=replace_by_fee
         )
 
         NetworkAPI.broadcast_tx_testnet(tx_hex)
@@ -778,6 +799,7 @@ class PrivateKeyTestnet(BaseKey):
         message=None,
         unspents=None,
         message_is_hex=False,
+        replace_by_fee=False
     ):  # pragma: no cover
         """Prepares a P2PKH transaction for offline signing.
 
@@ -813,6 +835,9 @@ class PrivateKeyTestnet(BaseKey):
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
+        :type replace_by_fee: ``bool``
         :returns: JSON storing data required to create an offline transaction.
         :rtype: ``str``
         """
@@ -826,6 +851,7 @@ class PrivateKeyTestnet(BaseKey):
             absolute_fee=absolute_fee,
             version='test',
             message_is_hex=message_is_hex,
+            replace_by_fee=replace_by_fee
         )
 
         data = {'unspents': [unspent.to_dict() for unspent in unspents], 'outputs': outputs}
@@ -1076,6 +1102,7 @@ class MultiSig:
         message=None,
         unspents=None,
         message_is_hex=False,
+        replace_by_fee=False
     ):  # pragma: no cover
         """Creates a signed P2SH transaction.
 
@@ -1106,6 +1133,8 @@ class MultiSig:
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the testnet blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
+        :type replace_by_fee: ``bool``
         :returns: The signed transaction as hex.
         :rtype: ``str``
         """
@@ -1127,6 +1156,7 @@ class MultiSig:
             absolute_fee=absolute_fee,
             version=self.version,
             message_is_hex=message_is_hex,
+            replace_by_fee=replace_by_fee
         )
 
         return create_new_transaction(self, unspents, outputs)
@@ -1144,6 +1174,7 @@ class MultiSig:
         message=None,
         unspents=None,
         message_is_hex=False,
+        replace_by_fee=False
     ):  # pragma: no cover
         """Prepares a P2SH transaction for offline signing.
 
@@ -1179,6 +1210,9 @@ class MultiSig:
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
+        :type replace_by_fee: ``bool``
         :returns: JSON storing data required to create an offline transaction.
         :rtype: ``str``
         """
@@ -1192,6 +1226,7 @@ class MultiSig:
             absolute_fee=absolute_fee,
             version='main',
             message_is_hex=message_is_hex,
+            replace_by_fee=replace_by_fee
         )
 
         data = {'unspents': [unspent.to_dict() for unspent in unspents], 'outputs': outputs}
@@ -1397,6 +1432,7 @@ class MultiSigTestnet:
         message=None,
         unspents=None,
         message_is_hex=False,
+        replace_by_fee=False
     ):  # pragma: no cover
         """Creates a signed P2SH transaction.
 
@@ -1427,6 +1463,8 @@ class MultiSigTestnet:
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the testnet blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
+        :type replace_by_fee: ``bool``
         :returns: The signed transaction as hex.
         :rtype: ``str``
         """
@@ -1448,6 +1486,7 @@ class MultiSigTestnet:
             absolute_fee=absolute_fee,
             version=self.version,
             message_is_hex=message_is_hex,
+            replace_by_fee=replace_by_fee
         )
 
         return create_new_transaction(self, unspents, outputs)
@@ -1465,6 +1504,7 @@ class MultiSigTestnet:
         message=None,
         unspents=None,
         message_is_hex=False,
+        replace_by_fee=False
     ):  # pragma: no cover
         """Prepares a P2SH transaction for offline signing.
 
@@ -1500,6 +1540,9 @@ class MultiSigTestnet:
         :param unspents: The UTXOs to use as the inputs. By default Bit will
                          communicate with the blockchain itself.
         :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :type unspents: ``list`` of :class:`~bit.network.meta.Unspent`
+        :param replace_by_fee: Whether to opt-in for replace-by-fee (BIP 125).
+        :type replace_by_fee: ``bool``
         :returns: JSON storing data required to create an offline transaction.
         :rtype: ``str``
         """
@@ -1513,6 +1556,7 @@ class MultiSigTestnet:
             absolute_fee=absolute_fee,
             version='test',
             message_is_hex=message_is_hex,
+            replace_by_fee=replace_by_fee
         )
 
         data = {'unspents': [unspent.to_dict() for unspent in unspents], 'outputs': outputs}

--- a/docs/source/guide/transactions.rst
+++ b/docs/source/guide/transactions.rst
@@ -140,6 +140,11 @@ absolute fee value of e.g. 150 satoshis for the transaction:
 
     >>> key.create_transaction(..., fee=150, absolute_fee=True)
 
+You can create a replaceable transaction whose fee can be later increased by a minimum of 1 sat/B (`BIP 125`_):
+
+    >>> key.send(..., replace_by_fee=True)
+    >>> key.create_transaction(..., replace_by_fee=True)
+
 For more information about transaction fees `read this`_.
 
 Unspent Consolidation
@@ -215,3 +220,4 @@ Each item must be an instance of :class:`~bit.network.meta.Unspent`.
 .. _read this: https://blog.blockchain.com/2016/12/15/bitcoin-transaction-fees-what-are-they-why-should-you-care
 .. _Branch-and-Bound: http://murch.one/wp-content/uploads/2016/11/erhardt2016coinselection.pdf
 .. _unspent transaction output: https://en.bitcoin.it/wiki/Transaction#Input
+.. _BIP 125: https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki

--- a/tests/network/test_meta.py
+++ b/tests/network/test_meta.py
@@ -26,7 +26,8 @@ class TestUnspent:
         unspent = Unspent(10000, 7, 'script', 'txid', 0)
 
         assert repr(unspent) == (
-            "Unspent(amount=10000, confirmations=7, " "script='script', txid='txid', txindex=0, " "segwit=False)"
+            "Unspent(amount=10000, confirmations=7, " "script='script', txid='txid', txindex=0, " "segwit=False, "
+            "sequence=4294967295)"
         )
 
     def test_set_type(self):

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1109,7 +1109,7 @@ class TestReplaceByFee:
         unspents = []
         for unspent in UNSPENTS_RBF:
             locked_unspent = Unspent.from_dict(unspent.to_dict())
-            locked_unspent.sequence = 0x00090000.to_bytes(4, byteorder='little')
+            locked_unspent.sequence = 50000
             locked_unspent.opt_in_for_RBF()
             unspents.append(locked_unspent)
 


### PR DESCRIPTION
This PR combines the two RBF implementation ideas (#122 and #123) and adds two tests to verify this new code.

Key changes of this PR:
* key.send(), key.create_transaction() and Key.prepare_transaction() now have a new optional boolean argument `replace_by_fee` which defaults to `False`.
* Unspent class has extra attribute `sequence` which defaults to constants.SEQUENCE (as in #123) and as a new opt_in_for_RBF() method.
* sanitize_tx_data() receives the new `replace_by_fee` argument and calls unspent.opt_in_for_RBF() if set to true.
* create_new_transaction() reads unspent.sequence and passes it into the inputs.
* the added tests are based in a mined RBF transaction that has two segwit inputs which is tested against the generated raw transactions (without the witnesses).

I ran all tests with `pytest` and everything passed.

Will close #122 and #123.
Closes #121 