### PR TITLE
URGENT: Downgrade BitCoreAPI

### DIFF
--- a/bit/network/services.py
+++ b/bit/network/services.py
@@ -973,11 +973,11 @@ class NetworkAPI:
         BlockchainAPI.get_transaction_by_id,
     ]
     GET_UNSPENT_MAIN = [
-        BlockchairAPI.get_unspent,
-        BitcoreAPI.get_unspent,  # No limit
-        SmartbitAPI.get_unspent,  # Limit 1000
         BlockstreamAPI.get_unspent,
+        BlockchairAPI.get_unspent,
+        SmartbitAPI.get_unspent,  # Limit 1000
         BlockchainAPI.get_unspent,
+        BitcoreAPI.get_unspent,  # No limit
     ]
     BROADCAST_TX_MAIN = [
         BlockchairAPI.broadcast_tx,
@@ -1004,10 +1004,10 @@ class NetworkAPI:
         SmartbitAPI.get_transaction_by_id_testnet,
     ]
     GET_UNSPENT_TEST = [
-        BlockchairAPI.get_unspent_testnet,
-        BitcoreAPI.get_unspent_testnet,  # No limit
-        SmartbitAPI.get_unspent_testnet,  # Limit 1000
         BlockstreamAPI.get_unspent_testnet,
+        BlockchairAPI.get_unspent_testnet,
+        SmartbitAPI.get_unspent_testnet,  # Limit 1000
+        BitcoreAPI.get_unspent_testnet,  # No limit
     ]
     BROADCAST_TX_TEST = [
         BlockchairAPI.broadcast_tx_testnet,


### PR DESCRIPTION
I haven't used bit for almost a month, but today I ran some code that uses bit. I noticed that the number of confirmations on my utxos was -1 like reported in issues #127 and #137. When I started digging into the cause of the problem, I found a much bigger problem: bitcoreAPI is returning non-existent UTXOs. This issue probably arises when using RBF transactions and doing fee bumping. Therefore it went undetected for such a long time. Check for yourselves:

`> https://api.bitcore.io/api/BTC/mainnet/address/32KiQZVWb4oSC1Urfa7CNr1kzVjMbPg4Yu/?unspent=true&limit=100`
```json
[
{"_id":"5f6a0d41c1032d4686c88b7f","chain":"BTC","network":"mainnet","coinbase":false,"mintIndex":1,"spentTxid":"","mintTxid":"6b5b2d0325b3e39a02ab5dbd26fbe5ab7796aa867f0804057d94bc8c786107d6","mintHeight":649506,"spentHeight":-2,"address":"32KiQZVWb4oSC1Urfa7CNr1kzVjMbPg4Yu","script":"a91406f0c4a74f1e5ea2955b46cccc0707063f75d2de87","value":134494,"confirmations":-1},
{"_id":"5f6a0891c1032d4686be5948","chain":"BTC","network":"mainnet","coinbase":false,"mintIndex":1,"spentTxid":"","mintTxid":"5b8d4986179e688598498ff2c093616653e8c5901d7d9c47b5fd779ff94de8e8","mintHeight":-3,"spentHeight":-2,"address":"32KiQZVWb4oSC1Urfa7CNr1kzVjMbPg4Yu","script":"a91406f0c4a74f1e5ea2955b46cccc0707063f75d2de87","value":136566,"confirmations":-1},
{"_id":"5f6a015fc1032d4686aecc0e","chain":"BTC","network":"mainnet","coinbase":false,"mintIndex":1,"spentTxid":"","mintTxid":"934aa2a335efb296ae33b73698fc70d82ec04f25a678f6680f0d4fbacd80e90a","mintHeight":-3,"spentHeight":-2,"address":"32KiQZVWb4oSC1Urfa7CNr1kzVjMbPg4Yu","script":"a91406f0c4a74f1e5ea2955b46cccc0707063f75d2de87","value":137602,"confirmations":-1}
]
```
The transactions `5b8d4986179e688598498ff2c093616653e8c5901d7d9c47b5fd779ff94de8e8` and `934aa2a335efb296ae33b73698fc70d82ec04f25a678f6680f0d4fbacd80e90a` DON'T EXIST in the mempool or blockchain, they are probably old transactions that were replaced by RBF and were never mined.

A correct response is, for example, the one from Blockstream API `https://blockstream.info/api/address/32KiQZVWb4oSC1Urfa7CNr1kzVjMbPg4Yu/utxo`

```json
[{"txid":"6b5b2d0325b3e39a02ab5dbd26fbe5ab7796aa867f0804057d94bc8c786107d6","vout":1,"status":{"confirmed":true,"block_height":649506,"block_hash":"0000000000000000000a64a49360b37f8708741e585db03c571890e5c99a9794","block_time":1600786257},"value":134494}]
```

Currently, smartbitAPI is down (`https://api.smartbit.com.au/v1/blockchain/address/32KiQZVWb4oSC1Urfa7CNr1kzVjMbPg4Yu`), and blockchairAPI is blocking my calls (`https://api.blockchair.com/bitcoin/dashboards/address/32KiQZVWb4oSC1Urfa7CNr1kzVjMbPg4Yu`)

------------

This PR redefines the preference for each API for the GET_UNSPENT_MAIN and GET_UNSPENT_TEST endpoints. For the above reasons, BitCoreAPI goes to the bottom. Because SmartbitAPI is down at the moment and BlockchairAPI seems to be taking the route of premium plans for a large choice of coins (https://api.blockchair.com/premium/plans) and is blocking my calls, BlockstreamAPI seems the best option right now. Blockstream runs their explorer on a fork of electrs that therefore is very fast, besides being run by a reputable company. 

I don't want to impose this specific order; what is important for me is that BitCore goes to the bottom of the list. Building transactions with fake UTXOs is quite disruptive, as you can imagine...

Possibly fixes #127 and fixes #137 