### PR TITLE
Change fee provider

### DIFF
--- a/bit/network/fees.py
+++ b/bit/network/fees.py
@@ -9,7 +9,7 @@ from requests.exceptions import ConnectionError, HTTPError, Timeout
 DEFAULT_FEE_FAST = 72
 DEFAULT_FEE_HOUR = 62
 DEFAULT_CACHE_TIME = 60 * 10
-URL = 'https://bitcoinfees.earn.com/api/v1/fees/recommended'
+URL = 'https://mempool.space/api/v1/fees/recommended'
 
 
 def set_fee_cache_time(seconds):


### PR DESCRIPTION
This pull request changes the fee provider from bitcoinfees.earn.com to mempool.space and fixes [#152](https://github.com/ofek/bit/issues/152).

The current fee provider (bitcoinfees.earn.com) is often suggesting network fees that are an order of magnitude greater than providers such as Blockchair, Blockstream, Mempool.space, as well as Bitcoin Core. This is unnecessarily wasteful, and even the "slow" network fee is high enough to be a next-block confirmation fee, usually actually two or three times *more* than the prevailing next-block fee.

I selected Mempool.space because of its seemingly unlimited API limit. At least, I didn't run into its API limit during testing.