### PR TITLE
Fix UnboundLocalError in select_coins

### DIFF
--- a/bit/transaction.py
+++ b/bit/transaction.py
@@ -313,6 +313,7 @@ def select_coins(target, fee, output_size, min_change, *, absolute_fee=False, co
             # To have a deterministic way of inserting inputs when
             # consolidating, we only shuffle the unspents otherwise.
             shuffle(unspents)
+        estimated_fee = 0
         while unspents:
             selected_coins.append(unspents.pop(0))
             estimated_fee = estimate_tx_fee(


### PR DESCRIPTION
 https://github.com/ofek/bit/blob/d351d1d819abfdb973411b4c8855d784ab58046c/bit/transaction.py#L316-L329
estimated_fee integer is initialized within the `while` block of select_coins, resulting in `UnboundLocalError` in the case when an empty container is provided for the `unspents` argument.
```
from bit.transaction import select_coins

# Should raise InsufficientFunds
s = select_coins(10000, 1, [42], 100, unspents=[])

UnboundLocalError: cannot access local variable 'estimated_fee' where it is not associated with a value
```

The PR proposes to initialize the `estimated_fee` integer right before the while condition.